### PR TITLE
MODOAIPMH-35 implement verb Identify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,13 @@
 
     <!-- Plugin versions -->
     <aspectj.version>1.8.9</aspectj.version>
-    <raml-module-builder.version>21.0.4</raml-module-builder.version>
+    <raml-module-builder.version>22.0.1</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
+    <time-adapters.version>1.1.3</time-adapters.version>
+    <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <restassured.version>2.9.0</restassured.version>
+    <junit.version>4.12</junit.version>
   </properties>
 
   <repositories>
@@ -99,6 +103,17 @@
       <artifactId>vertx-web</artifactId>
       <version>${vertx.version}</version>
     </dependency>
+    <!-- Jaxb dependencies -->
+    <dependency>
+      <groupId>com.migesok</groupId>
+      <artifactId>jaxb-java-time-adapters</artifactId>
+      <version>${time-adapters.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.jaxb2_commons</groupId>
+      <artifactId>jaxb2-basics-runtime</artifactId>
+      <version>${jaxb2-basics.version}</version>
+    </dependency>
 
     <!-- logging see http://www.slf4j.org/legacy.html -->
     <!-- we use SLF4J log4j for our logging interface -->
@@ -112,7 +127,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -121,6 +136,12 @@
       <version>${vertx.version}</version>
       <scope>test</scope>
       <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.restassured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>${restassured.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -188,7 +209,6 @@
             <configuration>
               <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
-              <commandlineArgs>-extension</commandlineArgs>
               <systemProperties>
                 <systemProperty>
                   <key>project.basedir</key>
@@ -306,6 +326,33 @@
         </executions>
       </plugin>
 
+      <!-- Replace the baseUri and the protocols in the RAMLs that have been copied to
+      apidocs directory so that they can be used via the local html api console. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <configuration>
+              <target if="http.port">
+                <replace token="baseUri: https://github.com/folio-org/mod-oai-pmh" value="baseUri: http://localhost:${http.port}"
+                         dir="${basedir}/target/classes/apidocs/raml">
+                  <include name="**/*.raml" />
+                </replace>
+                <replace token="protocols: [ HTTP, HTTPS ]" value="protocols: [ HTTP ]" dir="${basedir}/target/classes/apidocs/raml">
+                  <include name="**/*.raml" />
+                </replace>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
@@ -408,6 +455,8 @@
           <args>
             <arg>-Xfluent-api</arg>
             <arg>-Xannotate</arg>
+            <arg>-Xequals</arg>
+            <arg>-XhashCode</arg>
           </args>
           <plugins>
             <plugin>
@@ -419,6 +468,11 @@
               <groupId>org.jvnet.jaxb2_commons</groupId>
               <artifactId>jaxb2-basics-annotate</artifactId>
               <version>1.1.0</version>
+            </plugin>
+            <plugin>
+              <groupId>org.jvnet.jaxb2_commons</groupId>
+              <artifactId>jaxb2-basics</artifactId>
+              <version>${jaxb2-basics.version}</version>
             </plugin>
           </plugins>
         </configuration>
@@ -433,6 +487,18 @@
           <tagNameFormat>v@{project.version}</tagNameFormat>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
+        </configuration>
+      </plugin>
+
+      <!-- Enable jaxb validation for unit tests by default -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <configuration>
+          <systemPropertyVariables>
+            <jaxb.marshaller.enableValidation>true</jaxb.marshaller.enableValidation>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>vertx-web</artifactId>
       <version>${vertx.version}</version>
     </dependency>
+    <dependency>
+      <groupId>me.escoffier.vertx</groupId>
+      <artifactId>vertx-completable-future</artifactId>
+      <version>0.1.2</version>
+    </dependency>
     <!-- Jaxb dependencies -->
     <dependency>
       <groupId>com.migesok</groupId>

--- a/ramls/oai-pmh.raml
+++ b/ramls/oai-pmh.raml
@@ -27,8 +27,11 @@ resourceTypes:
   list: !include rtypes/list.raml
 
 /oai:
+  displayName: OAIPMH Repository
+  description: Service that processes OAI-PMH requests in RESTfull way
   /records:
     displayName: Records
+    description: The endpoint for "ListRecords" OAI-PMH verb which is used to harvest records from a repository.
     type:
       list:
         exampleCollection: !include examples/records.sample
@@ -45,6 +48,8 @@ resourceTypes:
                 value: !include examples/no_records_error.sample
 
     /{id}:
+      displayName: Record
+      description: The endpoint for "GetRecord" OAI-PMH verb which is used to retrieve an individual metadata record from a repository.
       uriParameters:
         id:
           description: The unique identifier of the item in the repository
@@ -77,6 +82,7 @@ resourceTypes:
 
   /identifiers:
     displayName: Identifiers
+    description: The endpoint for "ListIdentifiers" OAI-PMH verb which is an abbreviated form of "ListRecords", retrieving only headers rather than records from a repository.
     type:
       list:
         exampleCollection: !include examples/identifiers.sample
@@ -94,6 +100,7 @@ resourceTypes:
 
   /metadata_formats:
     displayName: MetadataFormats
+    description: The endpoint for "ListMetadataFormats" OAI-PMH verb which is used to retrieve the metadata formats available from a repository.
     type:
       list:
         exampleCollection: !include examples/metadata_formats.sample
@@ -123,6 +130,7 @@ resourceTypes:
 
   /sets:
     displayName: Sets
+    description: The endpoint for "ListSets" OAI-PMH verb which is used to retrieve the set structure of a repository.
     type:
       list:
         exampleCollection: !include examples/sets.sample
@@ -131,6 +139,7 @@ resourceTypes:
 
   /repository_info:
     displayName: RepositoryInfo
+    description: The endpoint for "Identify" OAI-PMH verb which is used to retrieve information about a repository.
     get:
       description: Returns information about a repository
       responses:

--- a/ramls/schemas/bindings.xjb
+++ b/ramls/schemas/bindings.xjb
@@ -5,10 +5,15 @@
                xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                xmlns:annox="http://annox.dev.java.net"
+               xmlns:oai="http://www.openarchives.org/OAI/2.0/"
                jaxb:version="2.1">
 
   <jaxb:globalBindings>
     <xjc:simple/>
+    <xjc:javaType name="java.time.Instant" xmlType="xs:dateTime"
+                  adapter="com.migesok.jaxb.adapter.javatime.InstantXmlAdapter"/>
+    <xjc:javaType name="java.time.Instant" xmlType="oai:UTCdatetimeType"
+                  adapter="com.migesok.jaxb.adapter.javatime.InstantXmlAdapter"/>
   </jaxb:globalBindings>
 
   <jaxb:bindings schemaLocation="OAI-PMH.xsd" node="//xs:schema">

--- a/ramls/traits/selective.raml
+++ b/ramls/traits/selective.raml
@@ -1,12 +1,16 @@
       queryParameters:
         from:
           description: 'UTC datetime value, which specifies a lower bound for datestamp-based selective harvesting'
-          type: date-only
+          type: string # using string instead of datetime to be able to validate if the passed parameter is valid to return proper OAI-PMH error
+          #pattern: \d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2]\d|3[0-1])T(?:[0-1]\d|2[0-3]):[0-5]\d:[0-5]\dZ
           required: false
+          example: 2018-10-15T15:16:17Z
         until:
           description: 'UTC datetime value, which specifies a upper bound for datestamp-based selective harvesting'
-          type: string
+          type: string # using string instead of datetime to be able to validate if the passed parameter is valid to return proper OAI-PMH error
+          #pattern: \d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2]\d|3[0-1])T(?:[0-1]\d|2[0-3]):[0-5]\d:[0-5]\dZ
           required: false
+          example: 2018-10-22T23:22:21Z
         set:
           description: 'setSpec value, which specifies set criteria for selective harvesting'
           type: string

--- a/src/main/java/org/folio/oaipmh/ResponseHelper.java
+++ b/src/main/java/org/folio/oaipmh/ResponseHelper.java
@@ -1,0 +1,98 @@
+package org.folio.oaipmh;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.openarchives.oai._2.OAIPMH;
+import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.File;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
+
+public class ResponseHelper {
+  private static final Logger logger = LoggerFactory.getLogger(ResponseHelper.class);
+  private static final String SCHEMA_PATH = "ramls" + File.separator + "schemas" + File.separator;
+  private static final String RESPONSE_SCHEMA = SCHEMA_PATH + "OAI-PMH.xsd";
+  private static ResponseHelper ourInstance;
+
+  static {
+    try {
+      ourInstance = new ResponseHelper();
+    } catch (JAXBException | SAXException e) {
+      logger.error("The jaxb marshaller could not be initialized");
+      throw new IllegalStateException("Marshaller is not available", e);
+    }
+  }
+
+  private Marshaller jaxbMarshaller;
+  private Unmarshaller jaxbUnmarshaller;
+
+  public static ResponseHelper getInstance() {
+    return ourInstance;
+  }
+
+  /**
+   * The main purpose is to initialize JAXB Marshaller and Unmarshaller to use the instances for business logic operations
+   */
+  private ResponseHelper() throws JAXBException, SAXException {
+    JAXBContext jaxbContext = JAXBContext.newInstance(OAIPMH.class);
+    jaxbMarshaller = jaxbContext.createMarshaller();
+    jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+
+    // Specifying OAI-PMH schema to validate response if the validation is enabled
+    if (Boolean.parseBoolean(System.getProperty("jaxb.marshaller.enableValidation"))) {
+      Schema oaipmhSchema = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI)
+                                         .newSchema(new StreamSource(this.getClass()
+                                                                         .getClassLoader()
+                                                                         .getResourceAsStream(RESPONSE_SCHEMA)));
+      jaxbMarshaller.setSchema(oaipmhSchema);
+      jaxbUnmarshaller.setSchema(oaipmhSchema);
+    }
+
+    // Specifying xsi:schemaLocation (which will trigger xmlns:xsi being added to RS as well)
+    jaxbMarshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
+      "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd");
+
+    // Specifying if output should be formatted
+    jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.parseBoolean(System.getProperty("jaxb.marshaller.formattedOutput")));
+  }
+
+  /**
+   * Marshals {@link OAIPMH} object and returns string representation
+   * @param response {@link OAIPMH} object to marshal
+   * @return marshaled {@link OAIPMH} object as string representation
+   * @throws JAXBException can be thrown, for example, if the {@link OAIPMH} object is invalid
+   */
+  public String writeToString(OAIPMH response) throws JAXBException {
+    StringWriter writer = new StringWriter();
+    jaxbMarshaller.marshal(response, writer);
+
+    return writer.toString();
+  }
+
+  /**
+   * Unmarshals {@link OAIPMH} object based on passed string
+   * @param oaipmhResponse the {@link OAIPMH} response in string representation
+   * @return the {@link OAIPMH} object based on passed string
+   * @throws JAXBException in case passed string is not valid OAIPMH representation
+   */
+  public OAIPMH stringToOaiPmh(String oaipmhResponse) throws JAXBException {
+    return (OAIPMH) jaxbUnmarshaller.unmarshal(new StringReader(oaipmhResponse));
+  }
+
+  /**
+   * @return Checks if the Jaxb marshaller initialized successfully
+   */
+  public boolean isJaxbInitialized() {
+    return jaxbMarshaller != null;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/GetOaiRepositoryInfoHelper.java
+++ b/src/main/java/org/folio/rest/impl/GetOaiRepositoryInfoHelper.java
@@ -1,0 +1,128 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.apache.log4j.Logger;
+import org.folio.oaipmh.ResponseHelper;
+import org.openarchives.oai._2.DeletedRecordType;
+import org.openarchives.oai._2.GranularityType;
+import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2.ObjectFactory;
+import org.openarchives.oai._2.VerbType;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+
+public class GetOaiRepositoryInfoHelper {
+
+  private static final Logger logger = Logger.getLogger(GetOaiRepositoryInfoHelper.class);
+
+  static final String REPOSITORY_NAME = "repository.name";
+  static final String REPOSITORY_BASE_URL = "repository.baseURL";
+  static final String REPOSITORY_ADMIN_EMAILS = "repository.adminEmails";
+  static final String REPOSITORY_PROTOCOL_VERSION_2_0 = "2.0";
+
+  private final Context ctx;
+  private final Map<String, String> okapiHeaders;
+
+  private ObjectFactory objectFactory = new ObjectFactory();
+
+
+  public GetOaiRepositoryInfoHelper(Map<String, String> okapiHeaders, Context ctx) {
+    this.okapiHeaders = okapiHeaders;
+    this.ctx = ctx;
+  }
+
+  public CompletableFuture<String> retrieveRepositoryInfo() {
+    CompletableFuture<String> future = new VertxCompletableFuture<>(ctx);
+    try {
+      OAIPMH oai = buildBaseResponse(VerbType.IDENTIFY)
+        .withIdentify(objectFactory.createIdentifyType()
+          .withRepositoryName(getRepositoryName(okapiHeaders))
+          .withBaseURL(getBaseURL())
+          .withProtocolVersion(REPOSITORY_PROTOCOL_VERSION_2_0)
+          .withEarliestDatestamp(getEarliestDatestamp())
+          .withGranularity(GranularityType.YYYY_MM_DD_THH_MM_SS_Z)
+          .withDeletedRecord(DeletedRecordType.NO)
+          .withAdminEmails(getEmails()));
+
+      String response = ResponseHelper.getInstance().writeToString(oai);
+      future.complete(response);
+    } catch (Exception e) {
+      logger.error("Error happened while processing Identify verb request", e);
+      future.completeExceptionally(e);
+    }
+
+    return future;
+  }
+
+  /**
+   * Return the repository name.
+   * For now, it is based on System property, but later it might be pulled from mod-configuration.
+   *
+   * @return repository name
+   */
+  private String getRepositoryName(Map<String, String> okapiHeaders) {
+    String repoName = System.getProperty(REPOSITORY_NAME);
+    if (repoName == null) {
+      throw new IllegalStateException("The required repository config 'repository.name' is missing");
+    }
+    return repoName + "_" + okapiHeaders.get(OKAPI_HEADER_TENANT);
+  }
+
+  /**
+   * Return the repository base URL.
+   * For now, it is based on System property, but later it might be pulled from mod-configuration.
+   *
+   * @return repository base URL
+   */
+  private String getBaseURL() {
+    String baseUrl = System.getProperty(REPOSITORY_BASE_URL);
+    if (baseUrl == null) {
+      throw new IllegalStateException("The required repository config 'repository.baseURL' is missing");
+    }
+    return baseUrl;
+  }
+
+  /**
+   * Return the earliest repository datestamp.
+   * For now, it always returns epoch instant, but later it might be pulled from mod-configuration.
+   *
+   * @return earliest datestamp
+   */
+  private Instant getEarliestDatestamp() {
+    return Instant.EPOCH.truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  /**
+   * Return the array of repository admin e-mails.
+   * For now, it is based on System property, but later it might be pulled from mod-configuration.
+   *
+   * @return repository name
+   */
+  private String[] getEmails() {
+    String emails = System.getProperty(REPOSITORY_ADMIN_EMAILS);
+    if (emails == null) {
+      throw new IllegalStateException("The required repository config 'repository.adminEmails' is missing");
+    }
+    return emails.split(",");
+  }
+
+  /**
+   * Creates basic {@link OAIPMH} with ResponseDate and Request details
+   * @param verb {@link VerbType}
+   * @return basic {@link OAIPMH}
+   */
+  private OAIPMH buildBaseResponse(VerbType verb) {
+    return objectFactory.createOAIPMH()
+      // According to spec the nanoseconds should not be used so truncate to seconds
+      .withResponseDate(Instant.now().truncatedTo(ChronoUnit.SECONDS))
+      .withRequest(objectFactory.createRequestType()
+        .withVerb(verb)
+        .withValue(getBaseURL()));
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,0 +1,55 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.oaipmh.ResponseHelper;
+import org.folio.rest.resource.interfaces.InitAPI;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * The class initializes system properties and checks if required configs are specified
+ */
+public class InitAPIs implements InitAPI {
+  private final Logger logger = LoggerFactory.getLogger(InitAPIs.class);
+
+  private static final String CONFIG_PATH = "config" + File.separator + "config.properties";
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    String configPath = System.getProperty("configPath", CONFIG_PATH);
+    try (InputStream configFile = InitAPIs.class.getClassLoader().getResourceAsStream(configPath)) {
+      if (configFile == null) {
+        throw new IllegalStateException(String.format("The config file %s is missing.", configPath));
+      }
+      final Properties confProperties = new Properties();
+      confProperties.load(configFile);
+
+      // Set system property from config file if no specified at runtime
+      Properties sysProps = System.getProperties();
+      confProperties.forEach((key, value) -> {
+        if (sysProps.putIfAbsent(key, value) == null) {
+          logger.info(String.format("The '%s' property was loaded from config file with its default value '%s'", key, value));
+        }
+      });
+
+      // Initialize ResponseWriter and check if jaxb marshaller is ready to operate
+      if (!ResponseHelper.getInstance().isJaxbInitialized()) {
+        throw new IllegalStateException("The jaxb marshaller failed initialization.");
+      }
+
+      resultHandler.handle(Future.succeededFuture(true));
+    } catch (Exception e) {
+      resultHandler.handle(Future.failedFuture(e));
+      logger.error("Unable to populate system properties", e);
+    }
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/OaiPmhImpl.java
+++ b/src/main/java/org/folio/rest/impl/OaiPmhImpl.java
@@ -123,7 +123,7 @@ public class OaiPmhImpl implements Oai {
    */
   private String getErrorMessage() {
     String errorMsg = "Sorry, we can't process your request.";
-    String emails = System.getProperty("repository.adminEmails");
+    String emails = System.getProperty(REPOSITORY_ADMIN_EMAILS);
     if (emails != null && !emails.isEmpty()) {
       errorMsg += " Please contact administrator(s): " + emails;
     }
@@ -141,6 +141,6 @@ public class OaiPmhImpl implements Oai {
                         .withResponseDate(Instant.now().truncatedTo(ChronoUnit.SECONDS))
                         .withRequest(objectFactory.createRequestType()
                                                   .withVerb(verb)
-                                                  .withValue(System.getProperty("repository.baseURL")));
+                                                  .withValue(System.getProperty(REPOSITORY_BASE_URL)));
   }
 }

--- a/src/main/java/org/folio/rest/impl/OaiPmhImpl.java
+++ b/src/main/java/org/folio/rest/impl/OaiPmhImpl.java
@@ -1,0 +1,146 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.oaipmh.ResponseHelper;
+import org.folio.rest.jaxrs.resource.Oai;
+import org.openarchives.oai._2.DeletedRecordType;
+import org.openarchives.oai._2.GranularityType;
+import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2.OAIPMHerrorcodeType;
+import org.openarchives.oai._2.ObjectFactory;
+import org.openarchives.oai._2.VerbType;
+
+import javax.ws.rs.core.Response;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+
+public class OaiPmhImpl implements Oai {
+  static final String REPOSITORY_NAME = "repository.name";
+  static final String REPOSITORY_BASE_URL = "repository.baseURL";
+  static final String REPOSITORY_ADMIN_EMAILS = "repository.adminEmails";
+  private static final String REPOSITORY_PROTOCOL_VERSION = "repository.protocolVersion";
+  static final String REPOSITORY_PROTOCOL_VERSION_2_0 = "2.0";
+  private final Logger logger = LoggerFactory.getLogger("mod-oai-pmh");
+  private ObjectFactory objectFactory = new ObjectFactory();
+
+  @Override
+  public void getOaiRecords(String resumptionToken, String from, String until, String set, String metadataPrefix,
+                            Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                            Context vertxContext) {
+    OAIPMH oai = buildBaseResponse(VerbType.LIST_RECORDS)
+      .withErrors(objectFactory.createOAIPMHerrorType().withCode(OAIPMHerrorcodeType.NO_RECORDS_MATCH));
+    oai.getRequest()
+       .withResumptionToken(resumptionToken)
+       //.withFrom(from != null ? Instant.parse(from) : null)
+       //.withUntil(until != null ? Instant.parse(until) : null)
+       .withSet(set)
+       .withMetadataPrefix(metadataPrefix);
+
+    try {
+      String response = ResponseHelper.getInstance().writeToString(oai);
+      asyncResultHandler.handle(succeededFuture(GetOaiRecordsResponse.respond422WithApplicationXml(response)));
+    } catch (Exception e) {
+      logger.error("Unexpected error happened while processing ListRecords verb request", e);
+      asyncResultHandler.handle(succeededFuture(GetOaiRecordsResponse.respond500WithTextPlain(getErrorMessage())));
+    }
+  }
+
+  @Override
+  public void getOaiRecordsById(String id, String metadataPrefix, Map<String, String> okapiHeaders,
+                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    OAIPMH oai = buildBaseResponse(VerbType.GET_RECORD)
+      .withErrors(objectFactory.createOAIPMHerrorType().withCode(OAIPMHerrorcodeType.ID_DOES_NOT_EXIST));
+    oai.getRequest().withIdentifier(id).withMetadataPrefix(metadataPrefix);
+
+    try {
+      String response = ResponseHelper.getInstance().writeToString(oai);
+      asyncResultHandler.handle(succeededFuture(GetOaiRecordsByIdResponse.respond422WithApplicationXml(response)));
+    } catch (Exception e) {
+      logger.error("Unexpected error happened while processing GetRecord verb request", e);
+      asyncResultHandler.handle(succeededFuture(GetOaiRecordsByIdResponse.respond500WithTextPlain(getErrorMessage())));
+    }
+  }
+
+  @Override
+  public void getOaiIdentifiers(String resumptionToken, String from, String until, String set, String metadataPrefix,
+                                Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                Context vertxContext) {
+    asyncResultHandler.handle(succeededFuture(GetOaiIdentifiersResponse.respond500WithTextPlain("The verb ListIdentifiers is not supported yet :(")));
+  }
+
+  @Override
+  public void getOaiMetadataFormats(String identifier, Map<String, String> okapiHeaders,
+                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(succeededFuture(GetOaiMetadataFormatsResponse.respond500WithTextPlain("The verb ListMetadataFormats is not supported yet :(")));
+  }
+
+  @Override
+  public void getOaiSets(String resumptionToken, Map<String, String> okapiHeaders,
+                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(succeededFuture(GetOaiSetsResponse.respond500WithTextPlain("The verb ListSets is not supported yet :(")));
+  }
+
+  @Override
+  public void getOaiRepositoryInfo(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                   Context vertxContext) {
+    try {
+      String repoName = System.getProperty(REPOSITORY_NAME);
+      String baseUrl = System.getProperty(REPOSITORY_BASE_URL);
+      String emails = System.getProperty(REPOSITORY_ADMIN_EMAILS);
+      if (repoName == null || baseUrl == null || emails == null) {
+        throw new IllegalStateException(String.format("One or more of the required repository configs missing: " +
+          "{repository.name: %s, repository.baseURL: %s, repository.adminEmails: %s}", repoName, baseUrl, emails));
+      }
+
+      OAIPMH oai = buildBaseResponse(VerbType.IDENTIFY)
+        .withIdentify(objectFactory.createIdentifyType()
+                                   .withRepositoryName(repoName + "_" + okapiHeaders.get(OKAPI_HEADER_TENANT))
+                                   .withBaseURL(baseUrl)
+                                   .withProtocolVersion(System.getProperty(REPOSITORY_PROTOCOL_VERSION, REPOSITORY_PROTOCOL_VERSION_2_0))
+                                   .withEarliestDatestamp(Instant.EPOCH.truncatedTo(ChronoUnit.SECONDS))
+                                   .withGranularity(GranularityType.YYYY_MM_DD_THH_MM_SS_Z)
+                                   .withDeletedRecord(DeletedRecordType.NO)
+                                   .withAdminEmails(emails.split(",")));
+      String response = ResponseHelper.getInstance().writeToString(oai);
+      asyncResultHandler.handle(succeededFuture(GetOaiRepositoryInfoResponse.respond200WithApplicationXml(response)));
+    } catch (Exception e) {
+      logger.error("Error happened while processing Identify verb request", e);
+      asyncResultHandler.handle(succeededFuture(GetOaiRepositoryInfoResponse.respond500WithTextPlain(getErrorMessage())));
+    }
+  }
+
+  /**
+   * Generates user friendly error message in case if the error happens while the requiest is being processed
+   * @return user friendly error message in case if the error happens while the requiest is being processed
+   */
+  private String getErrorMessage() {
+    String errorMsg = "Sorry, we can't process your request.";
+    String emails = System.getProperty("repository.adminEmails");
+    if (emails != null && !emails.isEmpty()) {
+      errorMsg += " Please contact administrator(s): " + emails;
+    }
+    return errorMsg;
+  }
+
+  /**
+   * Creates basic {@link OAIPMH} with ResponseDate and Request details
+   * @param verb {@link VerbType}
+   * @return basic {@link OAIPMH}
+   */
+  private OAIPMH buildBaseResponse(VerbType verb) {
+    return objectFactory.createOAIPMH()
+                        // According to spec the nanoseconds should not be used so truncate to seconds
+                        .withResponseDate(Instant.now().truncatedTo(ChronoUnit.SECONDS))
+                        .withRequest(objectFactory.createRequestType()
+                                                  .withVerb(verb)
+                                                  .withValue(System.getProperty("repository.baseURL")));
+  }
+}

--- a/src/main/resources/config/config.properties
+++ b/src/main/resources/config/config.properties
@@ -1,0 +1,9 @@
+# Properties describing repository. Mainly are going to be used by Identify verb
+repository.name=FOLIO_OAI_Repository
+repository.baseURL=http://tbd.later.folio.org/oai
+repository.protocolVersion=2.0
+repository.adminEmails=oai-pmh@folio.org
+
+# Jaxb settings
+jaxb.marshaller.enableValidation=true
+jaxb.marshaller.formattedOutput=false

--- a/src/main/resources/config/config.properties
+++ b/src/main/resources/config/config.properties
@@ -1,7 +1,6 @@
 # Properties describing repository. Mainly are going to be used by Identify verb
 repository.name=FOLIO_OAI_Repository
 repository.baseURL=http://tbd.later.folio.org/oai
-repository.protocolVersion=2.0
 repository.adminEmails=oai-pmh@folio.org
 
 # Jaxb settings

--- a/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
+++ b/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
@@ -1,0 +1,52 @@
+package org.folio.oaipmh;
+
+import org.junit.Test;
+import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2.OAIPMHerrorType;
+import org.openarchives.oai._2.OAIPMHerrorcodeType;
+import org.openarchives.oai._2.RequestType;
+
+import javax.xml.bind.JAXBException;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ResponseHelperTest {
+
+  @Test
+  public void tests() {
+    try {
+      ResponseHelper.getInstance().writeToString(new OAIPMH());
+      fail("JAXBException is expected because validation is enabled");
+    } catch (Exception e) {
+      assertTrue("JAXBException expected but was " + e.getMessage(), e instanceof JAXBException);
+    }
+
+    try {
+      OAIPMH oaipmh = new OAIPMH()
+        .withResponseDate(Instant.EPOCH)
+        .withRequest(new RequestType().withValue("oai"))
+        .withErrors(new OAIPMHerrorType().withCode(OAIPMHerrorcodeType.BAD_VERB).withValue("error"));
+
+      String result = ResponseHelper.getInstance().writeToString(oaipmh);
+      assertNotNull(result);
+
+      // Unmarshal string to OAIPMH and verify that these objects equals
+      OAIPMH oaipmh1FromString = ResponseHelper.getInstance().stringToOaiPmh(result);
+      assertEquals(oaipmh, oaipmh1FromString);
+    } catch (JAXBException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    try {
+      ResponseHelper.getInstance().writeToString(null);
+      fail("JAXBException is expected");
+    } catch (Exception e) {
+      assertTrue("IllegalArgumentException expected but was " + e.getMessage(), e instanceof IllegalArgumentException);
+    }
+  }
+}

--- a/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
+++ b/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
@@ -1,5 +1,6 @@
 package org.folio.oaipmh;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.openarchives.oai._2.OAIPMH;
 import org.openarchives.oai._2.OAIPMHerrorType;
@@ -16,13 +17,17 @@ import static org.junit.Assert.fail;
 
 public class ResponseHelperTest {
 
+  private static final Logger logger = Logger.getLogger(ResponseHelperTest.class);
+
   @Test
   public void tests() {
     try {
       ResponseHelper.getInstance().writeToString(new OAIPMH());
       fail("JAXBException is expected because validation is enabled");
+    } catch (JAXBException e) {
+      // expected behavior
     } catch (Exception e) {
-      assertTrue("JAXBException expected but was " + e.getMessage(), e instanceof JAXBException);
+      fail("JAXBException is expected, but was " + e.getMessage());
     }
 
     try {
@@ -38,15 +43,17 @@ public class ResponseHelperTest {
       OAIPMH oaipmh1FromString = ResponseHelper.getInstance().stringToOaiPmh(result);
       assertEquals(oaipmh, oaipmh1FromString);
     } catch (JAXBException e) {
-      e.printStackTrace();
+      logger.error("Failed to marshal or unmarshal OAI-PMH response", e);
       fail(e.getMessage());
     }
 
     try {
       ResponseHelper.getInstance().writeToString(null);
       fail("JAXBException is expected");
+    } catch (IllegalArgumentException e) {
+      // expected behavior
     } catch (Exception e) {
-      assertTrue("IllegalArgumentException expected but was " + e.getMessage(), e instanceof IllegalArgumentException);
+      fail("IllegalArgumentException expected but was " + e.getMessage());
     }
   }
 }

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -12,6 +12,8 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class InitAPIsTest {
 
+  private static final String TEST_PROP = "test.prop";
+
   /**
    * Tests {@link InitAPIs#init(Vertx, Context, Handler)}
    */
@@ -23,14 +25,14 @@ public class InitAPIsTest {
 
     // Specifying incorrect path to config file
     System.setProperty("configPath", "incorrectPath");
-    // Guaranty 'test.prop' is not available as Sys property. This property is defined in the 'config/config.properties' file
-    System.getProperties().remove("test.prop");
+    // Guarantee 'test.prop' is not available as Sys property. This property is defined in the 'config/config.properties' file
+    System.getProperties().remove(TEST_PROP);
     // Verify failure case
     initAPIs.init(vertx, vertx.getOrCreateContext(), resultHandler);
     context
       .assertTrue(resultHandler.failed())
       .assertTrue(resultHandler.cause() instanceof IllegalStateException)
-      .assertNull(System.getProperty("test.prop"));
+      .assertNull(System.getProperty(TEST_PROP));
 
     // Reset to default config path
     System.getProperties().remove("configPath");
@@ -40,6 +42,6 @@ public class InitAPIsTest {
     initAPIs.init(vertx, vertx.getOrCreateContext(), resultHandler);
     context
       .assertTrue(resultHandler.result())
-      .assertEquals("Test Value", System.getProperty("test.prop"));
+      .assertEquals("Test Value", System.getProperty(TEST_PROP));
   }
 }

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -1,0 +1,46 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class InitAPIsTest {
+
+  /**
+   * Tests {@link InitAPIs#init(Vertx, Context, Handler)}
+   */
+  @Test
+  public void init(TestContext context) {
+    // Check that 'test.prop' is not available as Sys property. This property is defined in the 'config/config.properties' file
+    context.assertNull(System.getProperty("test.prop"));
+
+    InitAPIs initAPIs = new InitAPIs();
+    Vertx vertx = Vertx.vertx();
+    Future<Boolean> resultHandler = Future.future();
+
+    // Specifying incorrect path to config file
+    System.setProperty("configPath", "incorrectPath");
+    // Verify failure case
+    initAPIs.init(vertx, vertx.getOrCreateContext(), resultHandler);
+    context
+      .assertTrue(resultHandler.failed())
+      .assertTrue(resultHandler.cause() instanceof IllegalStateException)
+      .assertNull(System.getProperty("test.prop"));
+
+    // Reset to default config path
+    System.getProperties().remove("configPath");
+
+    // Verify success case
+    resultHandler = Future.future();
+    initAPIs.init(vertx, vertx.getOrCreateContext(), resultHandler);
+    context
+      .assertTrue(resultHandler.result())
+      .assertEquals("Test Value", System.getProperty("test.prop"));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -17,15 +17,14 @@ public class InitAPIsTest {
    */
   @Test
   public void init(TestContext context) {
-    // Check that 'test.prop' is not available as Sys property. This property is defined in the 'config/config.properties' file
-    context.assertNull(System.getProperty("test.prop"));
-
     InitAPIs initAPIs = new InitAPIs();
     Vertx vertx = Vertx.vertx();
     Future<Boolean> resultHandler = Future.future();
 
     // Specifying incorrect path to config file
     System.setProperty("configPath", "incorrectPath");
+    // Guaranty 'test.prop' is not available as Sys property. This property is defined in the 'config/config.properties' file
+    System.getProperties().remove("test.prop");
     // Verify failure case
     initAPIs.init(vertx, vertx.getOrCreateContext(), resultHandler);
     context

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -1,0 +1,284 @@
+package org.folio.rest.impl;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Header;
+import com.jayway.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.oaipmh.ResponseHelper;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openarchives.oai._2.GranularityType;
+import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2.VerbType;
+
+import javax.xml.bind.JAXBException;
+import java.time.Instant;
+import java.util.Properties;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.folio.rest.impl.OaiPmhImpl.REPOSITORY_ADMIN_EMAILS;
+import static org.folio.rest.impl.OaiPmhImpl.REPOSITORY_BASE_URL;
+import static org.folio.rest.impl.OaiPmhImpl.REPOSITORY_NAME;
+import static org.folio.rest.impl.OaiPmhImpl.REPOSITORY_PROTOCOL_VERSION_2_0;
+
+@RunWith(VertxUnitRunner.class)
+public class OaiPmhImplTest {
+  private final static Logger logger = LoggerFactory.getLogger(OaiPmhImplTest.class);
+
+  // API paths
+  private final String rootPath = "/oai";
+  private final String listRecordsPath = rootPath + "/records";
+  private final String listIdentifiersPath = rootPath + "/identifiers";
+  private final String listMetadataFormatsPath = rootPath + "/metadata_formats";
+  private final String listSetsPath = rootPath + "/sets";
+  private final String identifyPath = rootPath + "/repository_info";
+
+  private final Header tenantHeader = new Header("X-Okapi-Tenant", "diku");
+  private final Header tokenHeader = new Header("X-Okapi-Token",
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkaWt1X2FkbWluIiwidXNlcl9pZCI6IjUwYjQyYmJmLTcwNzEtNTEwNi05NWQ2LTFkMjViZjczMjRmZiIsImlhdCI6MTUzODA0ODcyMiwidGVuYW50IjoiZGlrdSJ9.Qk3k_P9l025F-k3M-OoFJv6wPVAC7sepvgA8avEamZ8");
+  private final Header contentTypeHeaderXML = new Header("Content-Type", "application/xml");
+
+  private static Vertx vertx;
+
+  private static int port;
+
+  @BeforeClass
+  public static void setUpOnce(TestContext context) {
+    vertx = Vertx.vertx();
+    String moduleName = PomReader.INSTANCE.getModuleName()
+                                   .replaceAll("_", "-");  // RMB normalizes the dash to underscore, fix back
+    String moduleVersion = PomReader.INSTANCE.getVersion();
+    String moduleId = moduleName + "-" + moduleVersion;
+    logger.info("Test setup starting for " + moduleId);
+
+    port = NetworkUtils.nextFreePort();
+
+    JsonObject conf = new JsonObject()
+      .put("http.port", port)
+      .put(HttpClientMock2.MOCK_MODE, "true");
+
+    logger.info(String.format("mod-oai-pmh test: Deploying %s with %s", RestVerticle.class.getName(), Json.encode(conf)));
+
+    DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
+    vertx.deployVerticle(RestVerticle.class.getName(), opt, context.asyncAssertSuccess());
+    RestAssured.port = port;
+
+    logger.info("mod-oai-pmh Test: setup done. Using port " + port);
+  }
+
+  @AfterClass
+  public static void tearDownOnce(TestContext context) {
+    logger.info("Cleaning up after mod-oai-pmh Test");
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> async.complete()));
+  }
+
+  @Test
+  public void adminHealth(TestContext context) {
+    Async async = context.async();
+
+    // Simple GET request to see the module is running and we can talk to it.
+    given()
+      .get("/admin/health")
+      .then()
+      .log().all()
+      .statusCode(200);
+
+    async.complete();
+  }
+
+  @Test
+  public void getOaiRecords(TestContext context) throws JAXBException {
+    Async async = context.async();
+
+    RequestSpecification requestSpecification = createBaseRequest();
+    String response = test422WithXml(requestSpecification, listRecordsPath);
+
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    // Unmarshal string to OAIPMH and verify required data presents
+    OAIPMH oaipmh1FromString = ResponseHelper.getInstance().stringToOaiPmh(response);
+    context.assertNotNull(oaipmh1FromString)
+           .assertNotNull(oaipmh1FromString.getResponseDate())
+           .assertTrue(oaipmh1FromString.getResponseDate().isBefore(Instant.now()))
+           .assertNotNull(oaipmh1FromString.getRequest())
+           .assertNotNull(oaipmh1FromString.getRequest().getValue())
+           .assertEquals(VerbType.LIST_RECORDS, oaipmh1FromString.getRequest().getVerb())
+           .assertNotNull(oaipmh1FromString.getErrors())
+           .assertEquals(1, oaipmh1FromString.getErrors().size());
+    async.complete();
+  }
+
+  @Test
+  public void getOaiRecordsById(TestContext context) throws JAXBException {
+    Async async = context.async();
+
+    RequestSpecification requestSpecification = createBaseRequest();
+    String response = test422WithXml(requestSpecification, listRecordsPath + "/someId");
+
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    // Unmarshal string to OAIPMH and verify required data presents
+    OAIPMH oaipmh1FromString = ResponseHelper.getInstance().stringToOaiPmh(response);
+    context.assertNotNull(oaipmh1FromString)
+           .assertNotNull(oaipmh1FromString.getResponseDate())
+           .assertTrue(oaipmh1FromString.getResponseDate().isBefore(Instant.now()))
+           .assertNotNull(oaipmh1FromString.getRequest())
+           .assertNotNull(oaipmh1FromString.getRequest().getValue())
+           .assertEquals(VerbType.GET_RECORD, oaipmh1FromString.getRequest().getVerb())
+           .assertNotNull(oaipmh1FromString.getErrors())
+           .assertEquals(1, oaipmh1FromString.getErrors().size());
+
+    async.complete();
+  }
+
+  @Test
+  public void getOaiIdentifiers(TestContext context) {
+    Async async = context.async();
+
+    RequestSpecification requestSpecification = createBaseRequest();
+    String response = test500WithErrorMessage(requestSpecification, listIdentifiersPath);
+
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    async.complete();
+  }
+
+  @Test
+  public void getOaiMetadataFormats(TestContext context) {
+    Async async = context.async();
+
+    RequestSpecification requestSpecification = createBaseRequest();
+    String response = test500WithErrorMessage(requestSpecification, listMetadataFormatsPath);
+
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    async.complete();
+  }
+
+  @Test
+  public void getOaiSets(TestContext context) {
+    Async async = context.async();
+
+    RequestSpecification requestSpecification = createBaseRequest();
+    String response = test500WithErrorMessage(requestSpecification, listSetsPath);
+
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    async.complete();
+  }
+
+  private static String test422WithXml(RequestSpecification requestSpecification, String endpoint) {
+    return requestSpecification
+      .when()
+        .get(endpoint)
+      .then()
+        .statusCode(422)
+      .contentType(ContentType.XML)
+        .extract()
+          .body()
+            .asString();
+  }
+
+  private static String test500WithErrorMessage(RequestSpecification requestSpecification, String endpoint) {
+    return requestSpecification
+      .when()
+        .get(endpoint)
+      .then()
+        .statusCode(500)
+        .contentType(ContentType.TEXT)
+        .extract()
+          .body()
+            .asString();
+  }
+
+  @Test
+  public void getOaiRepositoryInfo(TestContext context) throws JAXBException {
+    Async async = context.async();
+    RequestSpecification requestSpecification = createBaseRequest();
+
+    // Remove required props
+    Properties sysProps = System.getProperties();
+    sysProps.remove(REPOSITORY_NAME);
+    sysProps.remove(REPOSITORY_BASE_URL);
+    sysProps.remove(REPOSITORY_ADMIN_EMAILS);
+
+    String response = test500WithErrorMessage(requestSpecification, identifyPath);
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+
+    // Set some required props but not all
+    sysProps.setProperty(REPOSITORY_NAME, REPOSITORY_NAME);
+    // Set 2 emails
+    String emails = "oaiAdminEmail1@folio.org,oaiAdminEmail2@folio.org";
+    sysProps.setProperty(REPOSITORY_ADMIN_EMAILS, emails);
+
+    response = test500WithErrorMessage(requestSpecification, identifyPath);
+    // Check that error message is returned
+    context.assertNotNull(response);
+    context.assertTrue(response.contains(emails));
+
+    // Set all required system properties
+    sysProps.setProperty(REPOSITORY_BASE_URL, REPOSITORY_BASE_URL);
+
+    response = requestSpecification
+      .when()
+        .get(identifyPath)
+      .then()
+        .statusCode(200)
+        .contentType(ContentType.XML)
+        .extract()
+          .body()
+            .asString();
+    // Check that error message is returned
+    context.assertNotNull(response);
+
+    // Unmarshal string to OAIPMH and verify required data presents
+    OAIPMH oaipmh1FromString = ResponseHelper.getInstance().stringToOaiPmh(response);
+    context.assertNotNull(oaipmh1FromString)
+           .assertNotNull(oaipmh1FromString.getResponseDate())
+           .assertTrue(oaipmh1FromString.getResponseDate().isBefore(Instant.now()))
+           .assertNotNull(oaipmh1FromString.getRequest())
+           .assertNotNull(oaipmh1FromString.getRequest().getValue())
+           .assertEquals(VerbType.IDENTIFY, oaipmh1FromString.getRequest().getVerb())
+           .assertNotNull(oaipmh1FromString.getIdentify())
+           .assertNotNull(oaipmh1FromString.getIdentify().getBaseURL())
+           .assertNotNull(oaipmh1FromString.getIdentify().getAdminEmails())
+           .assertEquals(2, oaipmh1FromString.getIdentify().getAdminEmails().size())
+           .assertNotNull(oaipmh1FromString.getIdentify().getEarliestDatestamp())
+           .assertEquals(GranularityType.YYYY_MM_DD_THH_MM_SS_Z, oaipmh1FromString.getIdentify().getGranularity())
+           .assertEquals(REPOSITORY_PROTOCOL_VERSION_2_0, oaipmh1FromString.getIdentify().getProtocolVersion())
+           .assertNotNull(oaipmh1FromString.getIdentify().getRepositoryName());
+
+    async.complete();
+  }
+
+  private RequestSpecification createBaseRequest() {
+    return RestAssured
+      .given()
+        .header(tokenHeader)
+        .header(tenantHeader)
+        .header(contentTypeHeaderXML);
+  }
+}

--- a/src/test/resources/config/config.properties
+++ b/src/test/resources/config/config.properties
@@ -1,0 +1,1 @@
+test.prop=Test Value


### PR DESCRIPTION
- The implementation of the Identify verb
- The rest of the verbs are implemented to return an error that the logic is not implemented yet
- Update raml so from/until parameters are defined as strings because if datetime is used, the parameters are passed to corresponding methods always null
- Modifying jaxb binding to use Instant as a date
- Adding maven-antrun-plugin to enable local html api console usage