### PR TITLE
Modoaipmh 54 improve marshalling of oai pmh responses to avoid redundant namespaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,8 @@
           "permissionsRequired": ["oai-pmh.records.collection.get"],
           "modulePermissions": [
             "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.source-record.marc-json.get"
           ]
         },
         {
@@ -21,7 +22,8 @@
           "permissionsRequired": ["oai-pmh.records.item.get"],
           "modulePermissions": [
             "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get"
+            "inventory-storage.instances.item.get",
+            "inventory-storage.instances.source-record.marc-json.get"
           ]
         },
         {

--- a/ramls/schemas/bindings.xjb
+++ b/ramls/schemas/bindings.xjb
@@ -37,4 +37,13 @@
       </jaxb:bindings>
     </jaxb:bindings>
   </jaxb:bindings>
+
+  <jaxb:bindings schemaLocation="MARC21slim.xsd" node="//xs:schema">
+    <jaxb:bindings node="//xs:complexType[@name='recordType']">
+      <annox:annotate>
+        <annox:annotate annox:class="javax.xml.bind.annotation.XmlRootElement" name="record" />
+      </annox:annotate>
+    </jaxb:bindings>
+  </jaxb:bindings>
+
 </jaxb:bindings>

--- a/src/main/java/org/folio/oaipmh/MetadataPrefix.java
+++ b/src/main/java/org/folio/oaipmh/MetadataPrefix.java
@@ -1,14 +1,13 @@
 package org.folio.oaipmh;
 
+import org.folio.oaipmh.mappers.Mapper;
+import org.folio.oaipmh.mappers.MarcXmlMapper;
+import org.folio.oaipmh.mappers.XSLTMapper;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import org.folio.oaipmh.mappers.Mapper;
-import org.folio.oaipmh.mappers.MarcXmlMapper;
-import org.folio.oaipmh.mappers.XSLTMapper;
-import org.w3c.dom.Node;
 
 
 /**
@@ -54,7 +53,7 @@ public enum MetadataPrefix {
     return FORMATS;
   }
 
-  public Node convert(String source) {
+  public byte[] convert(String source) {
     return mapper.convert(source);
   }
 

--- a/src/main/java/org/folio/oaipmh/ResponseHelper.java
+++ b/src/main/java/org/folio/oaipmh/ResponseHelper.java
@@ -1,8 +1,12 @@
 package org.folio.oaipmh;
 
+import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import gov.loc.marc21.slim.RecordType;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2_0.oai_dc.Dc;
+import org.purl.dc.elements._1.ObjectFactory;
 import org.xml.sax.SAXException;
 
 import javax.xml.bind.JAXBContext;
@@ -12,9 +16,12 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
 
@@ -25,32 +32,38 @@ public class ResponseHelper {
   private static final String DC_SCHEMA = SCHEMA_PATH + "oai_dc.xsd";
   private static final String SIMPLE_DC_SCHEMA = SCHEMA_PATH + "simpledc20021212.xsd";
   private static final String MARC21_SCHEMA = SCHEMA_PATH + "MARC21slim.xsd";
+
+  private static final Map<String, String> NAMESPACE_PREFIX_MAP = new HashMap<>();
+  private final NamespacePrefixMapper namespacePrefixMapper;
+
   private static ResponseHelper ourInstance;
 
   static {
+    NAMESPACE_PREFIX_MAP.put("http://www.loc.gov/MARC21/slim", "marc");
+    NAMESPACE_PREFIX_MAP.put("http://purl.org/dc/elements/1.1/", "dc");
+    NAMESPACE_PREFIX_MAP.put("http://www.openarchives.org/OAI/2.0/oai_dc/", "oai_dc");
     try {
       ourInstance = new ResponseHelper();
     } catch (JAXBException | SAXException e) {
-      logger.error("The jaxb marshaller could not be initialized");
-      throw new IllegalStateException("Marshaller is not available", e);
+      logger.error("The jaxb context could not be initialized");
+      throw new IllegalStateException("Marshaller and unmarshaller are not available", e);
     }
   }
+  private JAXBContext jaxbContext;
+  private Schema oaipmhSchema;
 
-  private Marshaller jaxbMarshaller;
-  private Unmarshaller jaxbUnmarshaller;
 
   public static ResponseHelper getInstance() {
     return ourInstance;
   }
 
   /**
-   * The main purpose is to initialize JAXB Marshaller and Unmarshaller to use the instances for business logic operations
+   * The main purpose is to initialize JAXB context to use the instances for business logic
+   * operations
    */
   private ResponseHelper() throws JAXBException, SAXException {
-    JAXBContext jaxbContext = JAXBContext.newInstance(OAIPMH.class);
-    jaxbMarshaller = jaxbContext.createMarshaller();
-    jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-
+    jaxbContext = JAXBContext.newInstance(OAIPMH.class, RecordType.class, Dc.class,
+      ObjectFactory.class);
     // Specifying OAI-PMH schema to validate response if the validation is enabled. Enabled by default if no config specified
     if (Boolean.parseBoolean(System.getProperty("jaxb.marshaller.enableValidation", Boolean.TRUE.toString()))) {
       ClassLoader classLoader = this.getClass().getClassLoader();
@@ -60,28 +73,36 @@ public class ResponseHelper {
         new StreamSource(classLoader.getResourceAsStream(SIMPLE_DC_SCHEMA)),
         new StreamSource(classLoader.getResourceAsStream(DC_SCHEMA))
       };
-      Schema oaipmhSchema = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI).newSchema(streamSources);
-      jaxbMarshaller.setSchema(oaipmhSchema);
-      jaxbUnmarshaller.setSchema(oaipmhSchema);
+      oaipmhSchema = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI).newSchema(streamSources);
     }
-
-    // Specifying xsi:schemaLocation (which will trigger xmlns:xsi being added to RS as well)
-    jaxbMarshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
-      "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd");
-
-    // Specifying if output should be formatted
-    jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.parseBoolean(System.getProperty("jaxb.marshaller.formattedOutput")));
+    namespacePrefixMapper = new NamespacePrefixMapper(){
+      @Override
+      public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+        return NAMESPACE_PREFIX_MAP.getOrDefault(namespaceUri, suggestion);
+      }
+    };
   }
 
   /**
    * Marshals {@link OAIPMH} object and returns string representation
    * @param response {@link OAIPMH} object to marshal
    * @return marshaled {@link OAIPMH} object as string representation
-   * @throws JAXBException can be thrown, for example, if the {@link OAIPMH} object is invalid
    */
   public String writeToString(OAIPMH response) {
     StringWriter writer = new StringWriter();
     try {
+      // Marshaller is not thread-safe, so we should create every time a new one
+      Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+      if (oaipmhSchema != null) {
+        jaxbMarshaller.setSchema(oaipmhSchema);
+      }
+      // Specifying xsi:schemaLocation (which will trigger xmlns:xsi being added to RS as well)
+      jaxbMarshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
+        "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd");
+      // Specifying if output should be formatted
+      jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.parseBoolean(System.getProperty("jaxb.marshaller.formattedOutput")));
+      // needed to replace the namespace prefixes with a more readable format.
+      jaxbMarshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", namespacePrefixMapper);
       jaxbMarshaller.marshal(response, writer);
     } catch (JAXBException e) {
       // In case there is an issue to marshal response, there is no way to handle it
@@ -95,16 +116,44 @@ public class ResponseHelper {
    * Unmarshals {@link OAIPMH} object based on passed string
    * @param oaipmhResponse the {@link OAIPMH} response in string representation
    * @return the {@link OAIPMH} object based on passed string
-   * @throws JAXBException in case passed string is not valid OAIPMH representation
    */
-  public OAIPMH stringToOaiPmh(String oaipmhResponse) throws JAXBException {
-    return (OAIPMH) jaxbUnmarshaller.unmarshal(new StringReader(oaipmhResponse));
+  public OAIPMH stringToOaiPmh(String oaipmhResponse) {
+    try {
+      // Unmarshaller is not thread-safe, so we should create every time a new one
+      Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+      if (oaipmhSchema != null) {
+        jaxbUnmarshaller.setSchema(oaipmhSchema);
+      }
+      return (OAIPMH) jaxbUnmarshaller.unmarshal(new StringReader(oaipmhResponse));
+    } catch (JAXBException e) {
+      // In case there is an issue to unmarshal response, there is no way to handle it
+      throw new IllegalStateException("The string cannot be converted to OAI-PMH response.", e);
+    }
   }
 
   /**
-   * @return Checks if the Jaxb marshaller initialized successfully
+   * Unmarshals {@link RecordType} or {@link Dc} objects based on passed byte array
+   * @param byteSource the {@link RecordType} or {@link Dc} objects in byte[] representation
+   * @return the object based on passed byte array
+   */
+  public Object bytesToObject(byte[] byteSource) {
+      try {
+        // Unmarshaller is not thread-safe, so we should create every time a new one
+        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+        if (oaipmhSchema != null) {
+          jaxbUnmarshaller.setSchema(oaipmhSchema);
+        }
+        return jaxbUnmarshaller.unmarshal(new ByteArrayInputStream(byteSource));
+      } catch (JAXBException e) {
+        // In case there is an issue to unmarshal byteSource, there is no way to handle it
+        throw new IllegalStateException("The byte array cannot be converted to JAXB object response.", e);
+      }
+  }
+
+  /**
+   * @return Checks if the Jaxb context initialized successfully
    */
   public boolean isJaxbInitialized() {
-    return jaxbMarshaller != null;
+    return jaxbContext != null;
   }
 }

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -7,6 +7,7 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.apache.log4j.Logger;
 import org.folio.oaipmh.MetadataPrefix;
 import org.folio.oaipmh.Request;
+import org.folio.oaipmh.ResponseHelper;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.openarchives.oai._2.MetadataType;
 import org.openarchives.oai._2.OAIPMH;
@@ -149,7 +150,9 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
     JsonObject source = sourceResponse.getBody();
     MetadataType metadata = new MetadataType();
     MetadataPrefix metadataPrefix = MetadataPrefix.fromName(request.getMetadataPrefix());
-    metadata.setAny(metadataPrefix.convert(source.toString()));
+    byte[] byteSource = metadataPrefix.convert(source.toString());
+    Object record = ResponseHelper.getInstance().bytesToObject(byteSource);
+    metadata.setAny(record);
     return metadata;
   }
 

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
@@ -115,7 +115,7 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
     return ResponseHelper.getInstance().writeToString(
       buildBaseResponse(request)
         .withErrors(new OAIPMHerrorType()
-          .withValue(String.format(Constants.RECORD_NOT_FOUND_ERROR, request.getIdentifier()))
+          .withValue(Constants.RECORD_NOT_FOUND_ERROR)
           .withCode(OAIPMHerrorcodeType.ID_DOES_NOT_EXIST)));
   }
 

--- a/src/main/java/org/folio/oaipmh/mappers/Mapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/Mapper.java
@@ -1,16 +1,14 @@
 package org.folio.oaipmh.mappers;
 
-import org.w3c.dom.Node;
-
 /**
  * Converts MarcJson format to XML format.
  */
 public interface Mapper {
   /**
-   * Converts json string to DOM Node representation of XML document.
+   * Converts json string to byte[] representation of XML document.
    *
    * @param source String representation of MarcJson source.
-   * @return the Node object that represents result XML document.
+   * @return byte[] that represents result XML document.
    */
-  Node convert(String source);
+  byte[] convert(String source);
 }

--- a/src/main/java/org/folio/oaipmh/mappers/MarcXmlMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/MarcXmlMapper.java
@@ -1,19 +1,17 @@
 package org.folio.oaipmh.mappers;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import javax.xml.transform.dom.DOMResult;
 
 import org.marc4j.MarcJsonReader;
 import org.marc4j.MarcReader;
-import org.marc4j.MarcWriter;
 import org.marc4j.MarcXmlWriter;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Record;
-import org.w3c.dom.Node;
 
 /**
  * Converts MarcJson format to MarcXML format.
@@ -24,33 +22,26 @@ public class MarcXmlMapper implements Mapper {
    * Convert MarcJson to MarcXML.
    *
    * @param source String representation of MarcJson source.
-   * @return DOM's Node representation of MarcXML
+   * @return byte[] representation of MarcXML
    */
-  public Node convert(String source) {
+  public byte[] convert(String source) {
     try (InputStream inputStream
            = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8))) {
       MarcReader marcJsonReader = new MarcJsonReader(inputStream);
-      DOMResult domResult = new DOMResult();
-      MarcWriter marcXmlWriter = new MarcXmlWriter(domResult);
-      while (marcJsonReader.hasNext()) {
-        Record record = marcJsonReader.next();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      Record record = marcJsonReader.next();
 
-        /*
-         * Fix indicators which comes like "ind1": "\\" in the source string and values are converted to '\'
-         * which contradicts to the MARC21slim.xsd schema. So replacing unexpected char by space
-         */
-        for (DataField data : record.getDataFields()) {
-          if (data.getIndicator1() == '\\') {
-            data.setIndicator1(' ');
-          }
-          if (data.getIndicator2() == '\\') {
-            data.setIndicator2(' ');
-          }
+      for (DataField data : record.getDataFields()) {
+        if (data.getIndicator1() == '\\') {
+          data.setIndicator1(' ');
         }
-        marcXmlWriter.write(record);
+        if (data.getIndicator2() == '\\') {
+          data.setIndicator2(' ');
+        }
       }
-      marcXmlWriter.close();
-      return domResult.getNode().getFirstChild().getFirstChild();
+
+      MarcXmlWriter.writeSingleRecord(record, out);
+      return out.toByteArray();
     } catch (IOException e) {
       throw new UncheckedIOException(e); //should never happen
     }

--- a/src/main/java/org/folio/oaipmh/mappers/XSLTMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/XSLTMapper.java
@@ -1,21 +1,17 @@
 package org.folio.oaipmh.mappers;
 
-import java.io.InputStream;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 
 
 /**
@@ -52,21 +48,21 @@ public class XSLTMapper extends MarcXmlMapper {
    * Convert MarcJson to MarcXML with XSLT post-processing.
    *
    * @param source {@inheritDoc}
-   * @return Node representation of XML after XSLT transformation
+   * @return byte[] representation of XML after XSLT transformation
    */
   @Override
-  public Node convert(String source) {
-    Node nodeSource = super.convert(source);
+  public byte[] convert(String source) {
+    byte[] marcXmlResult = super.convert(source);
     try {
-      DocumentBuilderFactory docbFactory = DocumentBuilderFactory.newInstance();
-      DocumentBuilder documentBuilder = docbFactory.newDocumentBuilder();
-      DOMSource domSource = new DOMSource(nodeSource);
-      DOMResult result = new DOMResult(documentBuilder.newDocument());
+      InputStream in = new ByteArrayInputStream(marcXmlResult);
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      Source streamSource = new StreamSource(in);
+      Result result = new StreamResult(out);
       Transformer transformer = template.newTransformer();
-      transformer.transform(domSource, result);
-      return ((Document) result.getNode()).getDocumentElement();
-    } catch (TransformerException | ParserConfigurationException e) {
-      throw new IllegalStateException(MAPPER_TRANSFORMATION_ERROR_MESSAGE, e);
+      transformer.transform(streamSource, result);
+      return out.toByteArray();
+    } catch (TransformerException e) {
+        throw new IllegalStateException(MAPPER_TRANSFORMATION_ERROR_MESSAGE, e);
     }
   }
 

--- a/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
+++ b/src/test/java/org/folio/oaipmh/ResponseHelperTest.java
@@ -50,22 +50,17 @@ class ResponseHelperTest {
 
   @Test
   void successCase() {
-    try {
-      OAIPMH oaipmh = new OAIPMH()
-        .withResponseDate(Instant.EPOCH)
-        .withRequest(new RequestType().withValue("oai"))
-        .withErrors(new OAIPMHerrorType().withCode(OAIPMHerrorcodeType.BAD_VERB).withValue("error"));
+    OAIPMH oaipmh = new OAIPMH()
+      .withResponseDate(Instant.EPOCH)
+      .withRequest(new RequestType().withValue("oai"))
+      .withErrors(new OAIPMHerrorType().withCode(OAIPMHerrorcodeType.BAD_VERB).withValue("error"));
 
-      String result = ResponseHelper.getInstance().writeToString(oaipmh);
-      assertThat(result, not(isEmptyOrNullString()));
+    String result = ResponseHelper.getInstance().writeToString(oaipmh);
+    assertThat(result, not(isEmptyOrNullString()));
 
-      // Unmarshal string to OAIPMH and verify that these objects equals
-      OAIPMH oaipmhFromString = ResponseHelper.getInstance().stringToOaiPmh(result);
+    // Unmarshal string to OAIPMH and verify that these objects equals
+    OAIPMH oaipmhFromString = ResponseHelper.getInstance().stringToOaiPmh(result);
 
-      assertThat(oaipmh, equalTo(oaipmhFromString));
-    } catch (JAXBException e) {
-      logger.error("Failed to unmarshal OAI-PMH response", e);
-      fail(e.getMessage());
-    }
+    assertThat(oaipmh, equalTo(oaipmhFromString));
   }
 }

--- a/src/test/java/org/folio/oaipmh/mappers/MapperTestHelper.java
+++ b/src/test/java/org/folio/oaipmh/mappers/MapperTestHelper.java
@@ -1,13 +1,14 @@
 package org.folio.oaipmh.mappers;
 
-import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
-import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -23,13 +24,13 @@ public class MapperTestHelper {
     return new String(encoded, StandardCharsets.UTF_8);
   }
 
-  static boolean validateDocumentAgainstSchema(Node node, String shemaFilePath) {
+  static boolean validateDocumentAgainstSchema(byte[] byteSource, String shemaFilePath) {
     try {
       SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
       URL schemaURL = new File(shemaFilePath).toURI().toURL();
       Schema schema = sf.newSchema(schemaURL);
       Validator validator = schema.newValidator();
-      DOMSource source = new DOMSource(node);
+      Source source = new StreamSource(new ByteArrayInputStream(byteSource));
       validator.validate(source);
       return true;
     } catch (SAXException | IOException e) {

--- a/src/test/java/org/folio/oaipmh/mappers/MarcXmlMapperTest.java
+++ b/src/test/java/org/folio/oaipmh/mappers/MarcXmlMapperTest.java
@@ -2,7 +2,6 @@ package org.folio.oaipmh.mappers;
 
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Node;
 
 import java.io.IOException;
 
@@ -10,25 +9,25 @@ import static org.folio.oaipmh.mappers.MapperTestHelper.validateDocumentAgainstS
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class MarcXmlMapperTest {
+class MarcXmlMapperTest {
 
   private static final Logger logger = Logger.getLogger(MarcXmlMapperTest.class);
 
   private static final String SCHEMA_FILE_PATH = "ramls/schemas/MARC21slim.xsd";
 
   @Test
-  public void correctJsonConvertingValidationTest() throws IOException {
+  void correctJsonConvertingValidationTest() throws IOException {
     logger.info("=== Test correct json file converting ===");
     String input = MapperTestHelper.getStringFromFile(StaticTestRecords.RESOURCES_CORRECT_JSON_MARC);
-    Node result = new MarcXmlMapper().convert(input);
+    byte[] result = new MarcXmlMapper().convert(input);
     assertThat(validateDocumentAgainstSchema(result, SCHEMA_FILE_PATH), is(true));
   }
 
   @Test
-  public void incorrectJsonConvertingValidationTest() throws IOException {
+  void incorrectJsonConvertingValidationTest() throws IOException {
     logger.info("=== Test incorrect json file converting ===");
     String input = MapperTestHelper.getStringFromFile(StaticTestRecords.RESOURCES_INCORRECT_JSON_MARC);
-    Node result = new MarcXmlMapper().convert(input);
+    byte[] result = new MarcXmlMapper().convert(input);
     assertThat(validateDocumentAgainstSchema(result, SCHEMA_FILE_PATH), is(false));
   }
 

--- a/src/test/java/org/folio/oaipmh/mappers/XSLTMapperTest.java
+++ b/src/test/java/org/folio/oaipmh/mappers/XSLTMapperTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class XSLTMapperTest {
 
@@ -29,16 +30,12 @@ class XSLTMapperTest {
 
   @Test
   void incorrectJsonConvertingToDCValidationTest() throws IOException {
-    int titlePosition = 320;
-    int emptyTitleLength = 11;
-    String expextedTitle = "<dc:title/>";
+    String emptyTitle = "<dc:title/>";
     logger.info("=== Test incorrect json file converting to Dublin Core ===");
     String input = MapperTestHelper.getStringFromFile(StaticTestRecords.RESOURCES_INCORRECT_JSON_MARC);
-    byte[] result = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
-    byte[] titleSubArray = new byte[emptyTitleLength];
-    System.arraycopy(result, titlePosition, titleSubArray, 0, emptyTitleLength);
-    String title = new String(titleSubArray);
-    assertThat(title, equalTo(expextedTitle));
+    byte[] bytesResult = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
+    String result = new String(bytesResult);
+    assertTrue(result.contains(emptyTitle));
   }
 
   @Test

--- a/src/test/java/org/folio/oaipmh/mappers/XSLTMapperTest.java
+++ b/src/test/java/org/folio/oaipmh/mappers/XSLTMapperTest.java
@@ -2,13 +2,11 @@ package org.folio.oaipmh.mappers;
 
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Node;
 
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,19 +23,22 @@ class XSLTMapperTest {
     logger.info("=== Test correct json file converting ===");
     String input = MapperTestHelper.getStringFromFile(StaticTestRecords
       .RESOURCES_CORRECT_JSON_MARC);
-    Node result = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
+    byte[] result = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
     assertThat(MapperTestHelper.validateDocumentAgainstSchema(result, SCHEMA_FILE_PATH), is(true));
   }
 
   @Test
   void incorrectJsonConvertingToDCValidationTest() throws IOException {
+    int titlePosition = 320;
+    int emptyTitleLength = 11;
+    String expextedTitle = "<dc:title/>";
     logger.info("=== Test incorrect json file converting to Dublin Core ===");
     String input = MapperTestHelper.getStringFromFile(StaticTestRecords.RESOURCES_INCORRECT_JSON_MARC);
-    Node result = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
-    String nodeName = result.getFirstChild().getLocalName();
-    assertThat(nodeName, equalTo("title"));
-    String titleValue =  result.getFirstChild().getNodeValue();
-    assertThat(titleValue, is(nullValue()));
+    byte[] result = new XSLTMapper(XSLT_MARC21SLIM2_OAIDC_XSL).convert(input);
+    byte[] titleSubArray = new byte[emptyTitleLength];
+    System.arraycopy(result, titlePosition, titleSubArray, 0, emptyTitleLength);
+    String title = new String(titleSubArray);
+    assertThat(title, equalTo(expextedTitle));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -30,7 +30,6 @@ import org.openarchives.oai._2.OAIPMHerrorType;
 import org.openarchives.oai._2.OAIPMHerrorcodeType;
 import org.openarchives.oai._2.VerbType;
 
-import javax.xml.bind.JAXBException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -40,9 +39,7 @@ import java.util.stream.Collectors;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.folio.oaipmh.Constants.*;
-import static org.folio.oaipmh.helpers.GetOaiRepositoryInfoHelper.REPOSITORY_ADMIN_EMAILS;
-import static org.folio.oaipmh.helpers.GetOaiRepositoryInfoHelper.REPOSITORY_NAME;
-import static org.folio.oaipmh.helpers.GetOaiRepositoryInfoHelper.REPOSITORY_PROTOCOL_VERSION_2_0;
+import static org.folio.oaipmh.helpers.GetOaiRepositoryInfoHelper.*;
 import static org.folio.rest.impl.OkapiMockServer.INVALID_IDENTIFIER;
 import static org.folio.rest.impl.OkapiMockServer.THREE_INSTANCES_DATE;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -51,20 +48,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_RESUMPTION_TOKEN;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.CANNOT_DISSEMINATE_FORMAT;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.ID_DOES_NOT_EXIST;
-import static org.openarchives.oai._2.OAIPMHerrorcodeType.NO_RECORDS_MATCH;
-import static org.openarchives.oai._2.VerbType.GET_RECORD;
-import static org.openarchives.oai._2.VerbType.IDENTIFY;
-import static org.openarchives.oai._2.VerbType.LIST_IDENTIFIERS;
-import static org.openarchives.oai._2.VerbType.LIST_METADATA_FORMATS;
-import static org.openarchives.oai._2.VerbType.LIST_RECORDS;
-import static org.openarchives.oai._2.VerbType.LIST_SETS;
+import static org.hamcrest.Matchers.*;
+import static org.openarchives.oai._2.OAIPMHerrorcodeType.*;
+import static org.openarchives.oai._2.VerbType.*;
 
 @ExtendWith(VertxExtension.class)
 class OaiPmhImplTest {
@@ -144,7 +130,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiIdentifiersSuccess() throws JAXBException {
+  void getOaiIdentifiersSuccess() {
     RequestSpecification request = createBaseRequest(LIST_IDENTIFIERS_PATH)
       .with()
         .param(METADATA_PREFIX_PARAM, MetadataPrefix.MARC_XML.getName());
@@ -160,7 +146,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiIdentifiersWithDateRange(MetadataPrefix prefix) throws JAXBException {
+  void getOaiIdentifiersWithDateRange(MetadataPrefix prefix) {
     OAIPMH oaipmh = verifyOaiListVerbWithDateRange(LIST_IDENTIFIERS, prefix);
 
     assertThat(oaipmh.getListIdentifiers(), is(notNullValue()));
@@ -173,7 +159,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiRecordsWithDateRange(MetadataPrefix prefix) throws JAXBException {
+  void getOaiRecordsWithDateRange(MetadataPrefix prefix) {
     OAIPMH oaipmh = verifyOaiListVerbWithDateRange(LIST_RECORDS, prefix);
 
     assertThat(oaipmh.getListRecords(), is(notNullValue()));
@@ -187,7 +173,7 @@ class OaiPmhImplTest {
           });
   }
 
-  private OAIPMH verifyOaiListVerbWithDateRange(VerbType verb, MetadataPrefix prefix) throws JAXBException {
+  private OAIPMH verifyOaiListVerbWithDateRange(VerbType verb, MetadataPrefix prefix) {
     String metadataPrefix = prefix.getName();
     String from = "2018-09-19T02:52:08Z";
     String until = THREE_INSTANCES_DATE;
@@ -214,7 +200,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS"})
-  void getOaiListVerbWithoutParams(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithoutParams(VerbType verb) {
     List<OAIPMHerrorType> errors = verifyResponseWithErrors(createBaseRequest(basePaths.get(verb)), verb, 400, 1).getErrors();
     OAIPMHerrorType error = errors.get(0);
     assertThat(error.getCode(), equalTo(BAD_ARGUMENT));
@@ -225,7 +211,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithWrongMetadataPrefix(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithWrongMetadataPrefix(VerbType verb) {
     String metadataPrefix = "abc";
     RequestSpecification request = createBaseRequest(basePaths.get(verb))
       .with()
@@ -241,7 +227,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithResumptionToken(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithResumptionToken(VerbType verb) {
     String resumptionToken = "abc";
     RequestSpecification request = createBaseRequest(basePaths.get(verb))
       .with()
@@ -257,7 +243,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithResumptionTokenAndWrongMetadataPrefix(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithResumptionTokenAndWrongMetadataPrefix(VerbType verb) {
     String resumptionToken = "abc";
     String metadataPrefix = "marc";
     RequestSpecification request = createBaseRequest(basePaths.get(verb))
@@ -282,7 +268,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithWrongSet(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithWrongSet(VerbType verb) {
     String metadataPrefix = MetadataPrefix.MARC_XML.getName();
     String set = "single";
 
@@ -303,7 +289,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithWrongDatesAndWrongSet(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithWrongDatesAndWrongSet(VerbType verb) {
     String metadataPrefix = MetadataPrefix.MARC_XML.getName();
     String from = "2018-09-19T02:52:08.873";
     String until = "2018-10-20T02:03:04.567";
@@ -336,7 +322,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithInvalidDateRange(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithInvalidDateRange(VerbType verb) {
     String metadataPrefix = MetadataPrefix.MARC_XML.getName();
     String from = "2018-12-19T02:52:08Z";
     String until = "2018-10-20T02:03:04Z";
@@ -359,7 +345,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
-  void getOaiListVerbWithNoRecordsFoundFromStorage(VerbType verb) throws JAXBException {
+  void getOaiListVerbWithNoRecordsFoundFromStorage(VerbType verb) {
     String metadataPrefix = MetadataPrefix.DC.getName();
     String from = OkapiMockServer.NO_RECORDS_DATE;
     String set = "all";
@@ -385,7 +371,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiListRecordsVerbWithOneNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) throws JAXBException {
+  void getOaiListRecordsVerbWithOneNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) {
     String from = OkapiMockServer.DATE_FOR_FOUR_INSTANCES_BUT_ONE_WITHOT_RECORD;
     RequestSpecification request = createBaseRequest(LIST_RECORDS_PATH)
       .with()
@@ -434,7 +420,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiRecordsByIdInvalidIdentifier(MetadataPrefix metadataPrefix) throws JAXBException {
+  void getOaiRecordsByIdInvalidIdentifier(MetadataPrefix metadataPrefix) {
     RequestSpecification requestSpecification = createBaseRequest(GET_RECORD_PATH)
       .pathParam(IDENTIFIER_PARAM, INVALID_IDENTIFIER)
       .with()
@@ -453,7 +439,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiListRecordsVerbWithOneInstanceButNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) throws JAXBException {
+  void getOaiListRecordsVerbWithOneInstanceButNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) {
     String from = OkapiMockServer.DATE_FOR_ONE_INSTANCE_BUT_WITHOT_RECORD;
     RequestSpecification request = createBaseRequest(LIST_RECORDS_PATH)
       .with()
@@ -473,7 +459,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiGetRecordVerbWithOneInstanceButNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) throws JAXBException {
+  void getOaiGetRecordVerbWithOneInstanceButNotFoundRecordFromStorage(MetadataPrefix metadataPrefix) {
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.NOT_FOUND_RECORD_INSTANCE_ID;
     RequestSpecification request = createBaseRequest(GET_RECORD_PATH)
       .with()
@@ -492,8 +478,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiGetRecordVerbWithWrongMetadataPrefix() throws
-    JAXBException {
+  void getOaiGetRecordVerbWithWrongMetadataPrefix() {
     String metadataPrefix = "mark_xml";
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.EXISTING_IDENTIFIER;
     RequestSpecification request = createBaseRequest(GET_RECORD_PATH)
@@ -507,7 +492,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiGetRecordVerbWithoutMetadataPrefix(VertxTestContext testContext) throws JAXBException {
+  void getOaiGetRecordVerbWithoutMetadataPrefix(VertxTestContext testContext) {
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.EXISTING_IDENTIFIER;
     RequestSpecification request = createBaseRequest(GET_RECORD_PATH)
       .with().pathParam(IDENTIFIER_PARAM, identifier);
@@ -520,7 +505,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiGetRecordVerbWithExistingIdentifier(MetadataPrefix metadataPrefix) throws JAXBException {
+  void getOaiGetRecordVerbWithExistingIdentifier(MetadataPrefix metadataPrefix) {
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.EXISTING_IDENTIFIER;
     RequestSpecification request = createBaseRequest(GET_RECORD_PATH)
       .with()
@@ -534,8 +519,7 @@ class OaiPmhImplTest {
 
   @ParameterizedTest
   @EnumSource(value = MetadataPrefix.class, names = { "MARC_XML", "DC" })
-  void getOaiGetRecordVerbWithNonExistingIdentifier(MetadataPrefix metadataPrefix) throws
-    JAXBException {
+  void getOaiGetRecordVerbWithNonExistingIdentifier(MetadataPrefix metadataPrefix) {
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.NON_EXISTING_IDENTIFIER;
     RequestSpecification request = createBaseRequest(GET_RECORD_PATH)
       .with()
@@ -551,7 +535,7 @@ class OaiPmhImplTest {
 
 
   @Test
-  void getOaiMetadataFormats(VertxTestContext testContext) throws JAXBException {
+  void getOaiMetadataFormats(VertxTestContext testContext) {
     logger.info("=== Test Metadata Formats without identifier ===");
 
     OAIPMH oaiPmhResponseWithoutIdentifier = verify200WithXml(createBaseRequest(LIST_METADATA_FORMATS_PATH), LIST_METADATA_FORMATS);
@@ -563,7 +547,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiMetadataFormatsWithExistingIdentifier(VertxTestContext testContext) throws JAXBException {
+  void getOaiMetadataFormatsWithExistingIdentifier(VertxTestContext testContext) {
     logger.info("=== Test Metadata Formats with existing identifier ===");
 
     String identifier = IDENTIFIER_PREFIX + OkapiMockServer.EXISTING_IDENTIFIER;
@@ -580,7 +564,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiMetadataFormatsWithNonExistingIdentifier(VertxTestContext testContext) throws JAXBException {
+  void getOaiMetadataFormatsWithNonExistingIdentifier(VertxTestContext testContext) {
     logger.info("=== Test Metadata Formats with non-existing identifier ===");
 
     // Check that error message is returned
@@ -611,7 +595,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiMetadataFormatsWithInvalidIdentifier(VertxTestContext testContext) throws JAXBException {
+  void getOaiMetadataFormatsWithInvalidIdentifier(VertxTestContext testContext) {
     logger.info("=== Test Metadata Formats with invalid identifier format ===");
 
     // Check that error message is returned
@@ -628,7 +612,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void testSuccessfulGetOaiSets(VertxTestContext testContext) throws JAXBException {
+  void testSuccessfulGetOaiSets(VertxTestContext testContext) {
     OAIPMH oaipmhFromString = verify200WithXml(createBaseRequest(LIST_SETS_PATH), LIST_SETS);
 
     assertThat(oaipmhFromString.getListSets(), is(notNullValue()));
@@ -658,7 +642,7 @@ class OaiPmhImplTest {
   }
 
   @Test
-  void getOaiRepositoryInfoSuccess(VertxTestContext testContext) throws JAXBException {
+  void getOaiRepositoryInfoSuccess(VertxTestContext testContext) {
     OAIPMH oaipmhFromString = verify200WithXml(createBaseRequest(IDENTIFY_PATH), IDENTIFY);
 
     assertThat(oaipmhFromString.getIdentify(), is(notNullValue()));
@@ -707,7 +691,7 @@ class OaiPmhImplTest {
     assertThat(oaipmhFromString.getRequest().getVerb(), equalTo(verb));
   }
 
-  private OAIPMH verify200WithXml(RequestSpecification request, VerbType verb) throws JAXBException {
+  private OAIPMH verify200WithXml(RequestSpecification request, VerbType verb) {
     String response = verifyWithCodeWithXml(request, 200);
 
     // Unmarshal string to OAIPMH and verify required data presents
@@ -748,7 +732,7 @@ class OaiPmhImplTest {
     return response;
   }
 
-  private OAIPMH verifyResponseWithErrors(RequestSpecification request, VerbType verb, int statusCode, int errorsCount) throws JAXBException {
+  private OAIPMH verifyResponseWithErrors(RequestSpecification request, VerbType verb, int statusCode, int errorsCount) {
     String response = verifyWithCodeWithXml(request, statusCode);
 
     // Unmarshal string to OAIPMH and verify required data presents


### PR DESCRIPTION
- Changed mappers return type to byte[]
- Added unmarshling of oairecord metadata to AbstractGetRecordHelper
- Moved the creation of marshaller and unmarshaller from the constructor to the methods
- Added missing permission to module descriptor