### PR TITLE
MODOAIPMH-12/MODOAIPMH-20 - use VertxCompletableFuture

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
@@ -43,7 +43,7 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
       HttpClientInterface httpClient = getOkapiClient(request.getOkapiHeaders());
 
       // 2. Search for instances
-      httpClient.request(storageHelper.buildItemsEndpoint(request), request.getOkapiHeaders(), false)
+      VertxCompletableFuture.from(ctx, httpClient.request(storageHelper.buildItemsEndpoint(request), request.getOkapiHeaders(), false))
         // 3. Verify response and build list of identifiers
         .thenApply(response -> buildListIdentifiers(request, response))
         .thenApply(identifiers -> {


### PR DESCRIPTION
The CompletableFuture uses its executors to perform tasks. When testing locally I noticed that a lot of threads actually created to execute those tasks. the log output was like:
```
2018-11-06 08:31:38,356 INFO  [Thread-12 ]: MarcXmlMapper reqId=551398/oai Marc json converted to Node after 385 ms
2018-11-06 08:31:38,358 INFO  [Thread-13 ]: MarcXmlMapper reqId=551398/oai Marc json converted to Node after 377 ms
2018-11-06 08:31:38,432 INFO  [Thread-4  ]: MarcXmlMapper reqId=551398/oai Marc json converted to Node after 591 ms
2018-11-06 08:31:38,537 INFO  [Thread-12 ]: ResponseHelper reqId=551398/oai Byte array converted to Object after 179 ms
2018-11-06 08:31:38,535 INFO  [Thread-10 ]: ResponseHelper reqId=551398/oai Byte array converted to Object after 185 ms
2018-11-06 08:31:38,631 INFO  [Thread-4  ]: ResponseHelper reqId=551398/oai Byte array converted to Object after 198 ms
2018-11-06 08:31:38,793 INFO  [Thread-4  ]: ResponseHelper reqId=551398/oai The OAIPMH response converted to string after 153 ms
```

So wrapping okapi client responses (which are in CompletableFuture) to execute further tasks on vert.x context. The log output in this case looks like following:
```
2018-11-06 08:18:13,332 INFO  [vert.x-eventloop-thread-0]: MarcXmlMapper reqId=251768/oai Marc json converted to Node after 2 ms
2018-11-06 08:18:13,335 INFO  [vert.x-eventloop-thread-0]: MarcXmlMapper reqId=251768/oai Marc json converted to Node after 2 ms
2018-11-06 08:18:13,342 INFO  [vert.x-eventloop-thread-0]: MarcXmlMapper reqId=251768/oai Marc json converted to Node after 2 ms
2018-11-06 08:18:13,381 INFO  [vert.x-eventloop-thread-0]: ResponseHelper reqId=251768/oai The OAIPMH response converted to string after 34 ms
```