### PR TITLE
MODOAIPMH-53 OAI-PMH: Response Compression (backend module)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,30 +40,6 @@
     </license>
   </licenses>
 
-  <properties>
-    <module_name>mod-oai-pmh</module_name>
-    <http.port>8081</http.port>
-    <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <!-- Plugin versions -->
-    <aspectj.version>1.8.9</aspectj.version>
-    <raml-module-builder.version>22.0.1</raml-module-builder.version>
-    <vertx.version>3.5.4</vertx.version>
-    <time-adapters.version>1.1.3</time-adapters.version>
-    <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
-    <log4j-slf4j.version>2.11.1</log4j-slf4j.version>
-    <restassured.version>2.9.0</restassured.version>
-    <junit.jupiter.version>5.3.1</junit.jupiter.version>
-    <junit.vintage.version>5.3.1</junit.vintage.version>
-    <junit.platform.version>1.3.1</junit.platform.version>
-    <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
-  </properties>
-
   <repositories>
     <repository>
       <id>folio-nexus</id>
@@ -89,6 +65,32 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <properties>
+    <module_name>mod-oai-pmh</module_name>
+    <http.port>8081</http.port>
+    <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Plugin versions -->
+    <aspectj.version>1.8.9</aspectj.version>
+    <raml-module-builder.version>23.1.0</raml-module-builder.version>
+    <vertx.version>3.5.4</vertx.version>
+    <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
+    <apache-httpclient.version>4.5.6</apache-httpclient.version>
+    <apache-commons-lang3.version>3.8.1</apache-commons-lang3.version>
+    <time-adapters.version>1.1.3</time-adapters.version>
+    <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
+    <marc4j.version>2.8.3</marc4j.version>
+    <mod-configuration-client.version>4.0.3</mod-configuration-client.version>
+    <log4j-slf4j.version>2.11.1</log4j-slf4j.version>
+    <restassured.version>2.9.0</restassured.version>
+    <junit.jupiter.version>5.3.1</junit.jupiter.version>
+  </properties>
+
   <dependencies>
     <!-- org.folio:domain-models-api-interfaces dependency goes with org.folio:domain-models-runtime -->
     <dependency>
@@ -109,7 +111,7 @@
     <dependency>
       <groupId>me.escoffier.vertx</groupId>
       <artifactId>vertx-completable-future</artifactId>
-      <version>0.1.2</version>
+      <version>${vertx-completable-future.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -128,19 +130,30 @@
       <version>${jaxb2-basics.version}</version>
     </dependency>
 
+    <!-- we use marc4j for converting marcJson to marcXml -->
+    <dependency>
+      <groupId>org.marc4j</groupId>
+      <artifactId>marc4j</artifactId>
+      <version>${marc4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${apache-httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${apache-commons-lang3.version}</version>
+    </dependency>
+
     <!-- logging see http://www.slf4j.org/legacy.html -->
     <!-- The RMB runtime defines usage of log4j2 for for vert.x logging interface -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j-slf4j.version}</version>
-    </dependency>
-
-    <!-- we use marc4j for converting marcJson to marcXml -->
-    <dependency>
-      <groupId>org.marc4j</groupId>
-      <artifactId>marc4j</artifactId>
-      <version>2.8.3</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -166,6 +179,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/folio/oaipmh/ResponseHelper.java
+++ b/src/main/java/org/folio/oaipmh/ResponseHelper.java
@@ -1,6 +1,5 @@
 package org.folio.oaipmh;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
 import gov.loc.marc21.slim.RecordType;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -27,6 +26,7 @@ import java.util.Map;
 
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
 
+@SuppressWarnings("squid:S1191") //The com.sun.xml.bind.marshaller.NamespacePrefixMapper is part of jaxb logic
 public class ResponseHelper {
   private static final Logger logger = LoggerFactory.getLogger(ResponseHelper.class);
   private static final String SCHEMA_PATH = "ramls" + File.separator + "schemas" + File.separator;
@@ -36,7 +36,7 @@ public class ResponseHelper {
   private static final String MARC21_SCHEMA = SCHEMA_PATH + "MARC21slim.xsd";
 
   private static final Map<String, String> NAMESPACE_PREFIX_MAP = new HashMap<>();
-  private final NamespacePrefixMapper namespacePrefixMapper;
+  private final com.sun.xml.bind.marshaller.NamespacePrefixMapper namespacePrefixMapper;
 
   private static ResponseHelper ourInstance;
 
@@ -76,7 +76,7 @@ public class ResponseHelper {
       };
       oaipmhSchema = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI).newSchema(streamSources);
     }
-    namespacePrefixMapper = new NamespacePrefixMapper() {
+    namespacePrefixMapper = new com.sun.xml.bind.marshaller.NamespacePrefixMapper() {
       @Override
       public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
         return NAMESPACE_PREFIX_MAP.getOrDefault(namespaceUri, suggestion);

--- a/src/main/java/org/folio/oaipmh/mappers/XSLTMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/XSLTMapper.java
@@ -4,6 +4,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.time.StopWatch;
 
+import javax.xml.XMLConstants;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -39,6 +41,7 @@ public class XSLTMapper extends MarcXmlMapper {
       InputStream inputStream = Thread.currentThread().getContextClassLoader()
         .getResourceAsStream(stylesheet);
       TransformerFactory transformerFactory = TransformerFactory.newInstance();
+      transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       transformerFactory.setURIResolver((href, base) -> new StreamSource(Thread.currentThread()
         .getContextClassLoader().getResourceAsStream(href)));
       template = transformerFactory.newTemplates(new StreamSource(inputStream));
@@ -60,6 +63,7 @@ public class XSLTMapper extends MarcXmlMapper {
     StopWatch timer = logger.isDebugEnabled() ? StopWatch.createStarted() : null;
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
       Transformer transformer = template.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.transform(new StreamSource(new ByteArrayInputStream(marcXmlResult)),
                         new StreamResult(out));
       return out.toByteArray();

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -86,8 +86,6 @@ public class OkapiMockServer {
   private void handleConfigurationModuleResponse(RoutingContext ctx) {
     if (ctx.request().getHeader(OKAPI_TENANT).equals(EXIST_CONFIG_TENANT)) {
       successResponse(ctx, getJsonObjectFromFile(CONFIG_TEST));
-    } else if (ctx.request().getHeader(OKAPI_TENANT).equals(NON_EXIST_CONFIG_TENANT)) {
-      successResponse(ctx, getJsonObjectFromFile(CONFIG_EMPTY));
     } else if (ctx.request().getHeader(OKAPI_TENANT).equals(ERROR_TENANT)) {
       failureResponse(ctx, 500, "Internal Server Error");
     } else {
@@ -105,8 +103,9 @@ public class OkapiMockServer {
       String json = getJsonObjectFromFile(String.format("/instance-storage/instances/marc-%s.json", instanceId));
       if (isNotEmpty(json)) {
         successResponse(ctx, json);
+      } else {
+        successResponse(ctx, getJsonObjectFromFile("/instance-storage/instances/marc.json"));
       }
-      successResponse(ctx, getJsonObjectFromFile("/instance-storage/instances/marc.json"));
     }
   }
 

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -5,7 +5,7 @@ name = PropertiesConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p [%-25t] %-20.25C{1} %m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%-25t] %-20.25C{1} %m%n
 
 rootLogger.level = debug
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
- pom.xml updates:
  - Switching to RMB of `v23.1.0`
  - Adding `httpclient`and `commons-lang3` dependencies instead of relying on transitive dependencies
- Unit test updates to verify different compressions
- Fixing issues highlighted by Sonar
  - Disabling `squid:S1191` for `ResponseHelper` because `NamespacePrefixMapper` is used by jaxb
  - Enabling `FEATURE_SECURE_PROCESSING` in `TransformerFactory` as suggested in `squid:S4435`