### PR TITLE
MODOAIPMH-63 Enable SRS usage by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+## 1.0.1 Unreleased
+ * The [mod-source-record-storage](https://github.com/folio-org/mod-source-record-storage) is enabled by default in scope of [MODOAIPMH-63](https://issues.folio.org/browse/MODOAIPMH-63). To enable usage of [mod-inventory-storage](https://github.com/folio-org/mod-inventory-storage), the `-Drepository.storage=INVENTORY` VM option should be specified.
 ## 1.0.0 (released on 11/22/2018)
  * Initial commit (see [MODOAIPMH-2](https://issues.folio.org/browse/MODOAIPMH-2) for more details)
  * The following schemas included in scope of [MODOAIPMH-6](https://issues.folio.org/browse/MODOAIPMH-6):

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ OAI-PMH | `jaxb.marshaller.formattedOutput` | `false` | Boolean value which is u
 Notes: 
 * The system default values can be overwritten by VM options e.g. `-Drepository.name=Specific_FOLIO_OAI-PMH_Repository`
 * Another configuration file can be specified via `-DconfigPath=<path_to_configs>` but the file should be accessible by ClassLoader
+* There is `repository.storage` system property defining which storage should be used to get records from. This configuration is not tenant specific but system wide therefore cannot be defined in [mod-configuration](https://github.com/folio-org/mod-configuration/) module. There are 2 allowed values:
+
+  | Value | Storage |
+  |  ---  |   ---   |  
+  | `SRS` | [mod-source-record-storage](https://github.com/folio-org/mod-source-record-storage) |
+  | `INVENTORY` | [mod-inventory-storage](https://github.com/folio-org/mod-inventory-storage) |
+  
+  The default value is `SRS`. To enable usage of the inventory storage, the `-Drepository.storage=INVENTORY` VM option should be specified.
 
 ### Issue tracker
 

--- a/src/main/java/org/folio/oaipmh/ResponseHelper.java
+++ b/src/main/java/org/folio/oaipmh/ResponseHelper.java
@@ -146,16 +146,19 @@ public class ResponseHelper {
    * @return the object based on passed byte array
    */
   public Object bytesToObject(byte[] byteSource) {
-    try {
+    StopWatch timer = logger.isDebugEnabled() ? StopWatch.createStarted() : null;
+    try(ByteArrayInputStream inputStream = new ByteArrayInputStream(byteSource)) {
       // Unmarshaller is not thread-safe, so we should create every time a new one
       Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
       if (oaipmhSchema != null) {
         jaxbUnmarshaller.setSchema(oaipmhSchema);
       }
-      return jaxbUnmarshaller.unmarshal(new ByteArrayInputStream(byteSource));
-    } catch (JAXBException e) {
+      return jaxbUnmarshaller.unmarshal(inputStream);
+    } catch (JAXBException | IOException e) {
       // In case there is an issue to unmarshal byteSource, there is no way to handle it
       throw new IllegalStateException("The byte array cannot be converted to JAXB object response.", e);
+    } finally {
+      logExecutionTime("Array of bytes converted to Object", timer);
     }
   }
 
@@ -169,7 +172,7 @@ public class ResponseHelper {
   private void logExecutionTime(final String msg, StopWatch timer) {
     if (timer != null) {
       timer.stop();
-      logger.debug(String.format("%s after %d ms", msg, timer.getTime()));
+      logger.debug("{} after {} ms", msg, timer.getTime());
     }
   }
 }

--- a/src/main/java/org/folio/oaipmh/helpers/storage/StorageHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/storage/StorageHelper.java
@@ -17,7 +17,7 @@ public interface StorageHelper {
    * Creates instance of the StorageHelper depending on the `repository.storage` system property.
    */
   static StorageHelper getInstance() {
-    String repositoryType = System.getProperty(REPOSITORY_STORAGE, INVENTORY_STORAGE);
+    String repositoryType = System.getProperty(REPOSITORY_STORAGE, SOURCE_RECORD_STORAGE);
     if (SOURCE_RECORD_STORAGE.equals(repositoryType)) {
       return new SourceRecordStorageHelper();
     } else if (INVENTORY_STORAGE.equals(repositoryType)) {


### PR DESCRIPTION
- SRS is enabled by default
- The Readme updated with information about `repository.storage` system property usage
- Debug logging of the execution time for bytes to jaxb object transformation