### PR TITLE
MODOAIPMH-86: Must support text/xml

### DIFF
--- a/ramls/oai-pmh.raml
+++ b/ramls/oai-pmh.raml
@@ -41,7 +41,7 @@ resourceTypes:
         404:
           description: "Item with a given ID and selective harvesting params (if any) not found"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false
@@ -61,7 +61,7 @@ resourceTypes:
           200:
             description: "Returns item with a given ID"
             body:
-              application/xml:
+              text/xml:
                 #schema: oai-pmh
                 example:
                   strict: false
@@ -69,7 +69,7 @@ resourceTypes:
           400:
             description: "Bad request, e.g. malformed query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
             body:
-              application/xml:
+              text/xml:
                 #schema: oai-pmh
                 example:
                   strict: false
@@ -77,7 +77,7 @@ resourceTypes:
           404:
             description: "Item with a given ID and selective harvesting params (if any) not found"
             body:
-              application/xml:
+              text/xml:
                 #schema: oai-pmh
                 example:
                   strict: false
@@ -100,7 +100,7 @@ resourceTypes:
         404:
           description: "Item with a given ID and selective harvesting params (if any) not found"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false
@@ -123,7 +123,7 @@ resourceTypes:
         404:
           description: "Item with a given ID and selective harvesting params (if any) not found"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false
@@ -131,7 +131,7 @@ resourceTypes:
         422:
           description: "The request was well-formed, but contains semantic errors"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false
@@ -155,7 +155,7 @@ resourceTypes:
         200:
           description: "Returns repository info"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false

--- a/ramls/rtypes/list.raml
+++ b/ramls/rtypes/list.raml
@@ -5,7 +5,7 @@
           200:
             description: "Returns a list of <<resourcePathName|!singularize>> items"
             body:
-              application/xml:
+              text/xml:
                 #schema: oai-pmh
                 example:
                   strict: false

--- a/ramls/traits/metadataPrefix.raml
+++ b/ramls/traits/metadataPrefix.raml
@@ -7,7 +7,7 @@
         422:
           description: "The request was well-formed, but contains semantic errors"
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false

--- a/ramls/traits/partitionable.raml
+++ b/ramls/traits/partitionable.raml
@@ -7,7 +7,7 @@
         400:
           description: "Bad request, e.g. malformed query parameter. Details of the error (e.g. name of the parameter or line/character number with malformed data) provided in the response."
           body:
-            application/xml:
+            text/xml:
               #schema: oai-pmh
               example:
                 strict: false

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
@@ -97,15 +97,15 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
     // According to oai-pmh.raml the service will return different http codes depending on the error
     Set<OAIPMHerrorcodeType> errorCodes = getErrorCodes(oai);
     if (errorCodes.contains(BAD_ARGUMENT) || errorCodes.contains(BAD_RESUMPTION_TOKEN)) {
-      return GetOaiIdentifiersResponse.respond400WithApplicationXml(responseBody);
+      return GetOaiIdentifiersResponse.respond400WithTextXml(responseBody);
     } else if (errorCodes.contains(CANNOT_DISSEMINATE_FORMAT)) {
-      return GetOaiIdentifiersResponse.respond422WithApplicationXml(responseBody);
+      return GetOaiIdentifiersResponse.respond422WithTextXml(responseBody);
     }
-    return GetOaiIdentifiersResponse.respond404WithApplicationXml(responseBody);
+    return GetOaiIdentifiersResponse.respond404WithTextXml(responseBody);
   }
 
   private javax.ws.rs.core.Response buildSuccessResponse(OAIPMH oai) {
-    return GetOaiIdentifiersResponse.respond200WithApplicationXml(ResponseHelper.getInstance().writeToString(oai));
+    return GetOaiIdentifiersResponse.respond200WithTextXml(ResponseHelper.getInstance().writeToString(oai));
   }
   /**
    * Builds {@link ListIdentifiersType} with headers if there is any item or {@code null}

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
@@ -66,7 +66,7 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
    * @return future with {@link OAIPMH} response
    */
   private javax.ws.rs.core.Response retrieveMetadataFormats(Request request) {
-    return GetOaiMetadataFormatsResponse.respond200WithApplicationXml(buildMetadataFormatTypesResponse(request));
+    return GetOaiMetadataFormatsResponse.respond200WithTextXml(buildMetadataFormatTypesResponse(request));
   }
 
   /**
@@ -85,7 +85,7 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
       logger.error("No instance found. Service responded with error: " + response.getError());
       throw new IllegalStateException(response.getError().toString());
     }
-    return GetOaiMetadataFormatsResponse.respond404WithApplicationXml(buildIdentifierNotFound(request));
+    return GetOaiMetadataFormatsResponse.respond404WithTextXml(buildIdentifierNotFound(request));
   }
 
   /**
@@ -93,7 +93,7 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
    * @return {@linkplain javax.ws.rs.core.Response Response}  with {@link OAIPMH} response
    */
   private javax.ws.rs.core.Response buildBadArgumentResponse(Request request) {
-    return GetOaiMetadataFormatsResponse.respond422WithApplicationXml(buildOaipmhWithBadArgumentError(request));
+    return GetOaiMetadataFormatsResponse.respond422WithTextXml(buildOaipmhWithBadArgumentError(request));
   }
 
   /**

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiRecordHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiRecordHelper.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.Set;
 
 import static org.folio.oaipmh.Constants.*;
-import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond200WithApplicationXml;
-import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond400WithApplicationXml;
-import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond404WithApplicationXml;
-import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond422WithApplicationXml;
+import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond200WithTextXml;
+import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond400WithTextXml;
+import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond404WithTextXml;
+import static org.folio.rest.jaxrs.resource.Oai.GetOaiRecordsByIdResponse.respond422WithTextXml;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.*;
 
 public class GetOaiRecordHelper extends AbstractGetRecordsHelper {
@@ -67,16 +67,16 @@ public class GetOaiRecordHelper extends AbstractGetRecordsHelper {
     // According to oai-pmh.raml the service will return different http codes depending on the error
     Set<OAIPMHerrorcodeType> errorCodes = getErrorCodes(oai);
     if (errorCodes.contains(BAD_ARGUMENT)) {
-      return respond400WithApplicationXml(responseBody);
+      return respond400WithTextXml(responseBody);
     } else if (errorCodes.contains(CANNOT_DISSEMINATE_FORMAT)) {
-      return respond422WithApplicationXml(responseBody);
+      return respond422WithTextXml(responseBody);
     }
-    return respond404WithApplicationXml(responseBody);
+    return respond404WithTextXml(responseBody);
   }
 
   @Override
   protected Response buildSuccessResponse(OAIPMH oai) {
-    return respond200WithApplicationXml(ResponseHelper.getInstance().writeToString(oai));
+    return respond200WithTextXml(ResponseHelper.getInstance().writeToString(oai));
   }
 
   @Override

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiRecordsHelper.java
@@ -37,7 +37,7 @@ public class GetOaiRecordsHelper extends AbstractGetRecordsHelper {
 
   @Override
   protected javax.ws.rs.core.Response buildSuccessResponse(OAIPMH oai) {
-    return GetOaiRecordsResponse.respond200WithApplicationXml(ResponseHelper.getInstance().writeToString(oai));
+    return GetOaiRecordsResponse.respond200WithTextXml(ResponseHelper.getInstance().writeToString(oai));
   }
 
   @Override
@@ -51,11 +51,11 @@ public class GetOaiRecordsHelper extends AbstractGetRecordsHelper {
     // According to oai-pmh.raml the service will return different http codes depending on the error
     Set<OAIPMHerrorcodeType> errorCodes = getErrorCodes(oai);
     if (errorCodes.contains(BAD_ARGUMENT) || errorCodes.contains(BAD_RESUMPTION_TOKEN)) {
-      return GetOaiRecordsResponse.respond400WithApplicationXml(responseBody);
+      return GetOaiRecordsResponse.respond400WithTextXml(responseBody);
     } else if (errorCodes.contains(CANNOT_DISSEMINATE_FORMAT)) {
-      return GetOaiRecordsResponse.respond422WithApplicationXml(responseBody);
+      return GetOaiRecordsResponse.respond422WithTextXml(responseBody);
     }
-    return GetOaiRecordsResponse.respond404WithApplicationXml(responseBody);
+    return GetOaiRecordsResponse.respond404WithTextXml(responseBody);
   }
 
   @Override

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiRepositoryInfoHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiRepositoryInfoHelper.java
@@ -63,7 +63,7 @@ public class GetOaiRepositoryInfoHelper extends AbstractHelper {
           .withDescriptions(getDescriptions(request)));
 
       String response = ResponseHelper.getInstance().writeToString(oai);
-      future.complete(GetOaiRepositoryInfoResponse.respond200WithApplicationXml(response));
+      future.complete(GetOaiRepositoryInfoResponse.respond200WithTextXml(response));
     } catch (Exception e) {
       logger.error("Error happened while processing Identify verb request", e);
       future.completeExceptionally(e);

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiSetsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiSetsHelper.java
@@ -33,14 +33,14 @@ public class GetOaiSetsHelper extends AbstractHelper {
         oai.withErrors(new OAIPMHerrorType()
           .withCode(BAD_RESUMPTION_TOKEN).withValue(RESUMPTION_TOKEN_FORMAT_ERROR));
         future.complete(GetOaiSetsResponse
-          .respond400WithApplicationXml(ResponseHelper.getInstance().writeToString(oai)));
+          .respond400WithTextXml(ResponseHelper.getInstance().writeToString(oai)));
         return future;
       }
 
       oai.withListSets(new ListSetsType()
         .withSets(getSupportedSetTypes()));
       future.complete(GetOaiSetsResponse
-        .respond200WithApplicationXml(ResponseHelper.getInstance().writeToString(oai)));
+        .respond200WithTextXml(ResponseHelper.getInstance().writeToString(oai)));
     } catch (Exception e) {
       logger.error("Error happened while processing ListSets verb request", e);
       future.completeExceptionally(e);

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -107,7 +107,7 @@ class OaiPmhImplTest {
   private static final int okapiPort = NetworkUtils.nextFreePort();
   private static final int mockPort = NetworkUtils.nextFreePort();
 
-  private static final String APPLICATION_XML_TYPE = "application/xml";
+  private static final String XML_TYPE = "text/xml";
   private static final String TENANT = OAI_TEST_TENANT;
   private static final String IDENTIFIER_PREFIX = "oai:test.folio.org:" + TENANT + "/";
   private static final String[] ENCODINGS = {"GZIP", "DEFLATE", "IDENTITY"};
@@ -869,7 +869,7 @@ class OaiPmhImplTest {
         .header(tokenHeader)
         .header(tenant)
         .basePath(basePath)
-        .contentType(APPLICATION_XML_TYPE);
+        .contentType(XML_TYPE);
   }
 
   private void verifyBaseResponse(OAIPMH oaipmhFromString, VerbType verb) {
@@ -898,7 +898,7 @@ class OaiPmhImplTest {
         .get()
       .then()
         .statusCode(code)
-        .contentType(APPLICATION_XML_TYPE);
+        .contentType(XML_TYPE);
 
     verifyContentEncodingHeader(response);
 


### PR DESCRIPTION
## Purpose
According to the OAI-PMH spec, the text/xml MIME type must be supported.  To meet this requirement, I'm switching `application/xml` -> `text/xml`

See https://issues.folio.org/browse/MODOAIPMH-86

## Notes
 - **N.B.** this is a breaking change!