### PR TITLE
MODOAIPMH-92 - RMB 29.3.0 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,25 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.6.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.12.1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <properties>
     <module_name>mod-oai-pmh</module_name>
     <http.port>8081</http.port>
@@ -75,19 +94,19 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Plugin versions -->
-    <aspectj.version>1.8.9</aspectj.version>
-    <raml-module-builder.version>26.1.2</raml-module-builder.version>
-    <vertx.version>3.5.4</vertx.version>
+    <aspectj.version>1.9.4</aspectj.version>
+    <raml-module-builder.version>29.3.0</raml-module-builder.version>
+    <vertx.version>3.8.5</vertx.version>
     <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
-    <apache-httpclient.version>4.5.6</apache-httpclient.version>
-    <apache-commons-lang3.version>3.8.1</apache-commons-lang3.version>
+    <apache-httpclient.version>4.5.11</apache-httpclient.version>
+    <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
     <time-adapters.version>1.1.3</time-adapters.version>
-    <jaxb2-basics.version>0.12.0</jaxb2-basics.version>
+    <jaxb2-basics.version>1.11.1</jaxb2-basics.version>
     <marc4j.version>2.8.3</marc4j.version>
     <mod-configuration-client.version>5.1.0</mod-configuration-client.version>
-    <log4j-slf4j.version>2.11.1</log4j-slf4j.version>
-    <restassured.version>2.9.0</restassured.version>
-    <junit.jupiter.version>5.3.1</junit.jupiter.version>
+    <log4j-slf4j.version>2.13.0</log4j-slf4j.version>
+    <restassured.version>4.2.0</restassured.version>
+    <junit.jupiter.version>5.6.0</junit.jupiter.version>
   </properties>
 
   <dependencies>
@@ -96,16 +115,6 @@
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>me.escoffier.vertx</groupId>
@@ -152,7 +161,10 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j-slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
     </dependency>
 
     <!-- test dependencies -->
@@ -164,27 +176,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>${restassured.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.jupiter.version}</version>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.jupiter.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.jupiter.version}</version>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -399,7 +403,7 @@
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.0.1</version>
         <executions>
           <execution>
             <id>rename-descriptor-outputs</id>
@@ -448,7 +452,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -545,7 +549,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
+        <version>2.22.2</version>
         <configuration>
           <systemPropertyVariables>
             <jaxb.marshaller.enableValidation>true</jaxb.marshaller.enableValidation>

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -1,13 +1,13 @@
 package org.folio.rest.impl;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.DecoderConfig;
-import com.jayway.restassured.config.DecoderConfig.ContentDecoder;
-import com.jayway.restassured.config.RestAssuredConfig;
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.response.ValidatableResponse;
-import com.jayway.restassured.specification.RequestSpecification;
+import io.restassured.RestAssured;
+import io.restassured.config.DecoderConfig;
+import io.restassured.config.DecoderConfig.ContentDecoder;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -58,7 +58,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.folio.oaipmh.Constants.*;
 import static org.folio.rest.impl.OkapiMockServer.INVALID_IDENTIFIER;
 import static org.folio.rest.impl.OkapiMockServer.OAI_TEST_TENANT;
@@ -190,8 +190,6 @@ class OaiPmhImplTest {
       .then()
         .log().all()
         .statusCode(200);
-
-    verifyContentEncodingHeader(response);
 
     getLogger().debug(String.format("==== adminHealth(%s) successfully completed ====", encoding));
   }
@@ -899,8 +897,6 @@ class OaiPmhImplTest {
       .then()
         .statusCode(code)
         .contentType(XML_TYPE);
-
-    verifyContentEncodingHeader(response);
 
     return response
       .extract()

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -162,7 +162,7 @@ public class OkapiMockServer {
   public void start(VertxTestContext context) {
     HttpServer server = vertx.createHttpServer();
 
-    server.requestHandler(defineRoutes()::accept).listen(port, context.succeeding(result -> {
+    server.requestHandler(defineRoutes()).listen(port, context.succeeding(result -> {
       logger.info("The server has started");
       context.completeNow();
     }));


### PR DESCRIPTION
### Purpose
https://issues.folio.org/browse/MODOAIPMH-92

## Approach
* migrated RMB to v29.3.0
* dependencies update
* removed content encoding tests since RMB v29 supports [compression by default](https://github.com/folio-org/raml-module-builder/blob/master/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java#L318)