### PR TITLE
MODOAIPMH-157 Preparation to MODOAIPMH release

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -16,7 +16,8 @@
             "inventory-storage.instances.source-record.marc-json.get",
             "source-storage.records.get",
             "source-storage.sourceRecords.get",
-            "configuration.entries.collection.get"
+            "configuration.entries.collection.get",
+            "inventory-storage.oai-pmh-view.instances.collection.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "oai-pmh",
-      "version": "2.1",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,21 +4,8 @@
   "provides": [
     {
       "id": "oai-pmh",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/verbs",
-          "permissionsRequired": ["oai-pmh.records.collection.get"],
-          "modulePermissions": [
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get",
-            "inventory-storage.instances.source-record.marc-json.get",
-            "source-storage.records.get",
-            "source-storage.sourceRecords.get",
-            "configuration.entries.collection.get"
-          ]
-        },
         {
           "methods": ["GET"],
           "pathPattern": "/oai/records",
@@ -31,53 +18,6 @@
             "source-storage.sourceRecords.get",
             "configuration.entries.collection.get"
           ]
-        },
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/records/{id}",
-          "permissionsRequired": ["oai-pmh.records.item.get"],
-          "modulePermissions": [
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get",
-            "inventory-storage.instances.source-record.marc-json.get",
-            "source-storage.records.get",
-            "source-storage.sourceRecords.get",
-            "configuration.entries.collection.get"
-          ]
-        },
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/repository_info",
-          "permissionsRequired": ["oai-pmh.identify.get"],
-          "modulePermissions": ["configuration.entries.collection.get"]
-        },
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/identifiers",
-          "permissionsRequired": ["oai-pmh.identifiers.collection.get"],
-          "modulePermissions": [
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get",
-            "source-storage.sourceRecords.get",
-            "configuration.entries.collection.get"
-          ]
-        },
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/metadata_formats",
-          "permissionsRequired": ["oai-pmh.metadata-formats.collection.get"],
-          "modulePermissions": [
-            "inventory-storage.instances.collection.get",
-            "inventory-storage.instances.item.get",
-            "source-storage.sourceRecords.get",
-            "configuration.entries.collection.get"
-          ]
-        },
-        {
-          "methods": ["GET"],
-          "pathPattern": "/oai/sets",
-          "permissionsRequired": ["oai-pmh.set.collection.get"],
-          "modulePermissions": ["configuration.entries.collection.get"]
         }
       ]
     },
@@ -113,46 +53,16 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "oai-pmh.records.item.get",
-      "displayName": "OAI-PMH - retrieve individual record",
-      "description": "Retrieve an individual metadata record"
-    },
-    {
-      "permissionName": "oai-pmh.identify.get",
-      "displayName": "OAI-PMH - get information about a repository",
-      "description": "Get information about a repository"
-    },
-    {
-      "permissionName": "oai-pmh.identifiers.collection.get",
-      "displayName": "OAI-PMH - get headers list",
-      "description": "Get headers list of record in specific format"
-    },
-    {
-      "permissionName": "oai-pmh.metadata-formats.collection.get",
-      "displayName": "OAI-PMH - get metadata formats available from a repository",
-      "description": "Get metadata formats available from a repository"
-    },
-    {
       "permissionName": "oai-pmh.records.collection.get",
       "displayName": "OAI-PMH - get list of records",
       "description": "Get records from repository"
-    },
-    {
-      "permissionName": "oai-pmh.set.collection.get",
-      "displayName": "oai-pmh - get set structure of a repository",
-      "description": "Get set structure of a repository"
     },
     {
       "permissionName": "oai-pmh.all",
       "displayName": "OAI-PMH - all permissions",
       "description": "Entire set of permissions needed to use OAI-PMH",
       "subPermissions": [
-        "oai-pmh.records.item.get",
-        "oai-pmh.identify.get",
-        "oai-pmh.identifiers.collection.get",
-        "oai-pmh.metadata-formats.collection.get",
-        "oai-pmh.records.collection.get",
-        "oai-pmh.set.collection.get"
+        "oai-pmh.records.collection.get"
       ]
     }
   ],

--- a/ramls/oai-pmh.raml
+++ b/ramls/oai-pmh.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: OAI-PMH API
 baseUri: https://github.com/folio-org/mod-oai-pmh
-version: v2.1
+version: v3
 protocols: [ HTTP, HTTPS ]
 
 documentation:

--- a/ramls/oai-pmh.raml
+++ b/ramls/oai-pmh.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: OAI-PMH API
 baseUri: https://github.com/folio-org/mod-oai-pmh
-version: v2
+version: v2.1
 protocols: [ HTTP, HTTPS ]
 
 documentation:


### PR DESCRIPTION
### PURPOSE
Change version of oai-pmh in  ModuleDescriptor and raml files from 2.0 to 3.0. Remove permissions for unused endpoints.
### LINKS
[https://issues.folio.org/browse/MODOAIPMH-157](url)