### PR TITLE
Compensate until date with +1 sec/day for marc21_witholdings and verb=listrecords

### DIFF
--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -261,7 +261,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     if (date != null) {
         paramMap.put("startDate", dateFormat.format(date));
       }
-    date = convertStringToDate(request.getUntil(), false);
+    date = convertStringToDate(request.getUntil(), true);
     if (date != null) {
         paramMap.put("endDate", dateFormat.format(date));
       }


### PR DESCRIPTION
## Purpose

As the until date filtering in inventory view is non-inclusive, we need to compensate the until date with either +1 second (if datetime) or +1 day in cases when date-only is supplied in from param.