### PR TITLE
MODOAIPMH-220: Perform uniqueness validation for sets endpoints

### DIFF
--- a/ramls/examples/filtering_condition_value_collection.sample
+++ b/ramls/examples/filtering_condition_value_collection.sample
@@ -1,24 +1,44 @@
 {
-  "filteringConditions" : [
+  "filteringConditions": [
     {
-      "name" : "location",
-      "values" : ["location 1", "location 2", "location 3"]
+      "name": "location",
+      "values": [
+        "location 1",
+        "location 2",
+        "location 3"
+      ]
     },
     {
-      "name" : "resourceType",
-      "values" : ["resourceType 1", "resourceType 2", "resourceType 3"]
+      "name": "resourceType",
+      "values": [
+        "resourceType 1",
+        "resourceType 2",
+        "resourceType 3"
+      ]
     },
     {
-      "name" : "format",
-      "values" : ["format 1", "format 2", "format 3"]
+      "name": "format",
+      "values": [
+        "format 1",
+        "format 2",
+        "format 3"
+      ]
     },
     {
-      "name" : "illPolicy",
-      "values" : ["illPolicy 1", "illPolicy 2", "illPolicy 3"]
+      "name": "illPolicy",
+      "values": [
+        "illPolicy 1",
+        "illPolicy 2",
+        "illPolicy 3"
+      ]
     },
     {
-      "name" : "materialType",
-      "values" : ["materialType 1", "materialType 2", "materialType 3"]
-    },
+      "name": "materialType",
+      "values": [
+        "materialType 1",
+        "materialType 2",
+        "materialType 3"
+      ]
+    }
   ]
 }

--- a/ramls/examples/folioSet.sample
+++ b/ramls/examples/folioSet.sample
@@ -2,9 +2,9 @@
   "id" : "88dfac11-1caf-4470-9ad1-d533f6360bdd",
   "name" : "example set",
   "description" : "example description",
-  "setSpec" : "EXAMPLE:SET:SPEC"
+  "setSpec" : "EXAMPLE:SET:SPEC",
   "createdDate" : "2020-07-27T11:19:58.293+0000",
-  "createdByUserId" : "ba332b37-1e74-4e95-b61f-a220401ef0bb"
+  "createdByUserId" : "ba332b37-1e74-4e95-b61f-a220401ef0bb",
   "updatedDate" : "2020-08-02T12:23:57.298+0000",
   "updatedByUserId" : "ba332b37-1e74-4e95-b61f-a220401ef0bb"
 }

--- a/src/main/java/org/folio/oaipmh/dao/impl/SetDaoImpl.java
+++ b/src/main/java/org/folio/oaipmh/dao/impl/SetDaoImpl.java
@@ -34,7 +34,6 @@ import io.vertx.sqlclient.RowSet;
 @Repository
 public class SetDaoImpl implements SetDao {
 
-
   private static final String ALREADY_EXISTS_ERROR_MSG = "Set with id '%s' already exists";
   private static final String NOT_FOUND_ERROR_MSG = "Set with id '%s' was not found";
 

--- a/src/main/resources/liquibase/tenant/changelog.xml
+++ b/src/main/resources/liquibase/tenant/changelog.xml
@@ -8,4 +8,6 @@
   <include file="scripts/2020-07-16--10-00-create-instnace-ids-table.xml" relativeToChangelogFile="true"/>
   <include file="scripts/2020-07-27--19-17-fix_primary_key.xml" relativeToChangelogFile="true"/>
   <include file="scripts/2020-07-20--9-00-import-sample-data.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/2020-08-28--11-00-add-unique-constraint-for-name-and-set_spec-columns.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
+

--- a/src/main/resources/liquibase/tenant/scripts/2020-08-28--11-00-add-unique-constraint-for-name-and-set_spec-columns.xml
+++ b/src/main/resources/liquibase/tenant/scripts/2020-08-28--11-00-add-unique-constraint-for-name-and-set_spec-columns.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet  id="2020-08-28--11-00-add-unique-constraint-to-set.set_spec-column " author="Illia Daliek">
+    <addUniqueConstraint  columnNames="setSpec"
+                          constraintName="set_spec_unique_constraint"
+                          schemaName="${database.defaultSchemaName}"
+                          tableName="set"/>
+    <addUniqueConstraint  columnNames="name"
+                          constraintName="name_unique_constraint"
+                          schemaName="${database.defaultSchemaName}"
+                          tableName="set"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
@@ -1,7 +1,7 @@
 package org.folio.oaipmh.service.impl;
 
-import static java.util.Objects.nonNull;
 import static java.lang.String.format;
+import static java.util.Objects.nonNull;
 import static org.folio.oaipmh.Constants.ILL_POLICIES;
 import static org.folio.oaipmh.Constants.INSTANCE_FORMATS;
 import static org.folio.oaipmh.Constants.INSTANCE_TYPES;

--- a/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
@@ -1,6 +1,7 @@
 package org.folio.oaipmh.service.impl;
 
 import static java.util.Objects.nonNull;
+import static java.lang.String.format;
 import static org.folio.oaipmh.Constants.ILL_POLICIES;
 import static org.folio.oaipmh.Constants.INSTANCE_FORMATS;
 import static org.folio.oaipmh.Constants.INSTANCE_TYPES;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.ws.rs.NotFoundException;
 
@@ -46,6 +48,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.pgclient.PgException;
 
 @ExtendWith(VertxExtension.class)
 class SetServiceImplTest {
@@ -55,9 +58,12 @@ class SetServiceImplTest {
   private static final String NONEXISTENT_SET_ID = "a3bd69dd-d50b-4aa6-accb-c1f9abaada55";
   private static final String TEST_USER_ID = "30fde4be-2d1a-4546-8d6c-b468caca2720";
 
-  private static final String EXPECTED_NOT_FOUND_MSG = String.format("Set with id '%s' was not found", NONEXISTENT_SET_ID);
-  private static final String EXPECTED_ITEM_WITH_ID_ALREADY_EXISTS_MSG = String.format("Set with id '%s' already exists",
+  private static final String EXPECTED_NOT_FOUND_MSG = format("Set with id '%s' was not found", NONEXISTENT_SET_ID);
+  private static final String EXPECTED_ITEM_WITH_ID_ALREADY_EXISTS_MSG = format("Set with id '%s' already exists",
       EXISTENT_SET_ID);
+  private static final String DUPLICATE_KEY_VALUE_VIOLATES_UNIQUE_CONSTRAINT_ERROR_MSG = "duplicate key value violates unique constraint \"%s\"";
+  private static final String SET_SPEC_UNIQUE_CONSTRAINT = "set_spec_unique_constraint";
+  private static final String NAME_UNIQUE_CONSTRAINT = "name_unique_constraint";
 
   private static final FolioSet INITIAL_TEST_SET_ENTRY = new FolioSet().withId(EXISTENT_SET_ID)
     .withName("test name")
@@ -68,9 +74,9 @@ class SetServiceImplTest {
     .withDescription("update description")
     .withSetSpec("update SetSpec");
 
-  private static final FolioSet POST_SET_ENTRY = new FolioSet().withName("update name")
-    .withDescription("update description")
-    .withSetSpec("update SetSpec");
+  private static final FolioSet POST_SET_ENTRY = new FolioSet().withName("post name")
+    .withDescription("post description")
+    .withSetSpec("post SetSpec");
 
   private static final int mockPort = NetworkUtils.nextFreePort();
 
@@ -115,10 +121,19 @@ class SetServiceImplTest {
 
   @AfterEach
   void cleanUp(VertxTestContext testContext) {
-    setDao.deleteSetById(EXISTENT_SET_ID, TEST_TENANT_ID)
-      .onComplete(result -> {
-        testContext.completeNow();
+    setDao.getSetList(0, 100, TEST_TENANT_ID).onSuccess(folioSetCollection -> {
+      List<Future> list = new ArrayList<>();
+      folioSetCollection.getSets().forEach(set -> {
+        list.add(setDao.deleteSetById(set.getId(), TEST_TENANT_ID));
       });
+      CompositeFuture.all(list).onComplete(result -> {
+        if(result.failed()) {
+          testContext.failNow(result.cause());
+        } else {
+          testContext.completeNow();
+        }
+      });
+    });
   }
 
   @Test
@@ -198,13 +213,7 @@ class SetServiceImplTest {
         verifyMainSetData(POST_SET_ENTRY, savedSet, false);
         assertEquals(TEST_USER_ID, savedSet.getCreatedByUserId());
         assertNotNull(savedSet.getCreatedDate());
-        setDao.deleteSetById(savedSet.getId(), TEST_TENANT_ID)
-          .onComplete(res -> {
-            if (res.failed()) {
-              testContext.failNow(res.cause());
-            }
-            testContext.completeNow();
-          });
+        testContext.completeNow();
       });
   }
 
@@ -219,6 +228,38 @@ class SetServiceImplTest {
           POST_SET_ENTRY.setId(null);
           testContext.completeNow();
         }));
+    });
+  }
+
+  @Test
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedSetSpecValue(VertxTestContext testContext) {
+    testContext.verify(() -> {
+      setService.saveSet(POST_SET_ENTRY, TEST_TENANT_ID, TEST_USER_ID).onComplete(result -> {
+        FolioSet setWithExistedSetSpecValue = result.result();
+        setWithExistedSetSpecValue.setId(UUID.randomUUID().toString());
+        setWithExistedSetSpecValue.setName("unique name");
+        setService.saveSet(setWithExistedSetSpecValue, TEST_TENANT_ID, TEST_USER_ID).onFailure(throwable -> {
+          assertTrue(throwable instanceof PgException);
+          assertEquals(format(DUPLICATE_KEY_VALUE_VIOLATES_UNIQUE_CONSTRAINT_ERROR_MSG, SET_SPEC_UNIQUE_CONSTRAINT), throwable.getMessage());
+          testContext.completeNow();
+        });
+      });
+    });
+  }
+
+  @Test
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedNameValue(VertxTestContext testContext) {
+    testContext.verify(() -> {
+      setService.saveSet(POST_SET_ENTRY, TEST_TENANT_ID, TEST_USER_ID).onComplete(result -> {
+        FolioSet setWithExistedNameValue = result.result();
+        setWithExistedNameValue.setId(UUID.randomUUID().toString());
+        setWithExistedNameValue.setSetSpec("unique setSpec");
+        setService.saveSet(setWithExistedNameValue, TEST_TENANT_ID, TEST_USER_ID).onFailure(throwable -> {
+          assertTrue(throwable instanceof PgException);
+          assertEquals(format(DUPLICATE_KEY_VALUE_VIOLATES_UNIQUE_CONSTRAINT_ERROR_MSG, NAME_UNIQUE_CONSTRAINT), throwable.getMessage());
+          testContext.completeNow();
+        });
+      });
     });
   }
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
@@ -5,7 +5,6 @@ import static java.util.Objects.nonNull;
 import static org.folio.rest.impl.OkapiMockServer.OAI_TEST_TENANT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
@@ -254,6 +254,9 @@ class OaiPmhSetImplTest {
         .statusCode(201)
         .contentType(ContentType.JSON);
 
+      String oldValue = POST_SET_ENTRY.getName();
+      POST_SET_ENTRY.setName("unique value for name");
+
       request = createBaseRequest(SET_PATH, ContentType.JSON).body(POST_SET_ENTRY);
       request.when()
         .post()
@@ -261,6 +264,7 @@ class OaiPmhSetImplTest {
         .statusCode(422)
         .contentType(ContentType.JSON)
         .body("errors[0].message", equalTo(format(DUPLICATE_KEY_VALUE_VIOLATES_UNIQUE_CONSTRAINT_ERROR_MSG, SET_SPEC_UNIQUE_CONSTRAINT)));
+      POST_SET_ENTRY.setName(oldValue);
       testContext.completeNow();
     });
   }


### PR DESCRIPTION
### PURPOSE
Add unqiue constraints for both name and setSpec columns. 
Jira: https://issues.folio.org/browse/MODOAIPMH-220
 **name unique validation**
![name unique](https://user-images.githubusercontent.com/60663044/91710391-d766aa80-eb8c-11ea-9ad8-1105bcb94a36.PNG)
 **setSpec unique validation**
![set spec unique](https://user-images.githubusercontent.com/60663044/91710392-d7ff4100-eb8c-11ea-9086-855c8c934a01.PNG)

