### PR TITLE
MODOAIPMH-220: Perform uniqueness validation for sets endpoints

### DIFF
--- a/src/main/java/org/folio/rest/impl/OaiPmhSetImpl.java
+++ b/src/main/java/org/folio/rest/impl/OaiPmhSetImpl.java
@@ -209,7 +209,7 @@ public class OaiPmhSetImpl implements OaiPmhSets, OaiPmhFilteringConditions {
 
   private String getFieldName(Map<Character, String> pgErrorsMap) {
     String error = pgErrorsMap.get('D');
-    String val = (error.split("\\)")[0].split("\\(")[1]);
+    String val = error.split("\\(")[2].replace("::text))=", "");
     if (val.contains("set_spec")) {
       return val.replace("_spec", "Spec");
     }

--- a/src/main/resources/liquibase/tenant/changelog.xml
+++ b/src/main/resources/liquibase/tenant/changelog.xml
@@ -1,7 +1,7 @@
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
   <include file="scripts/2020-07-07--16-00-create-set-table.xml" relativeToChangelogFile="true"/>
   <include file="scripts/2020-07-07--16-00-create-filtering-conditions-table.xml" relativeToChangelogFile="true"/>
@@ -11,5 +11,5 @@
   <include file="scripts/2020-08-20--12-00-enhance-set-table.xml" relativeToChangelogFile="true"/>
   <include file="scripts/2020-08-28--11-00-add-unique-constraint-for-name-and-set_spec-columns.xml" relativeToChangelogFile="true"/>
   <include file="scripts/2020-09-02--17-00-drop-sample-data.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/2020-09-03--12-00-add-case-insensitive-unique-constraints.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
-

--- a/src/main/resources/liquibase/tenant/scripts/2020-09-03--12-00-add-case-insensitive-unique-constraints.xml
+++ b/src/main/resources/liquibase/tenant/scripts/2020-09-03--12-00-add-case-insensitive-unique-constraints.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet  id="2020-08-28--12-30-drop-liquibase-unique-constraint-from-both-set_spec-and-name-columns" author="Illia Daliek">
+    <dropUniqueConstraint tableName="set_lb"
+                          schemaName="${database.defaultSchemaName}"
+                          constraintName="set_spec_unique_constraint"
+                          uniqueColumns="set_spec"/>
+    <dropUniqueConstraint tableName="set_lb"
+                          schemaName="${database.defaultSchemaName}"
+                          constraintName="name_unique_constraint"
+                          uniqueColumns="name"/>
+  </changeSet>
+
+  <changeSet  id="2020-08-28--11-00-add-case-insensitive-unique-constraint-to-both-set_spec-and-name-columns" author="Illia Daliek">
+    <sql>
+      CREATE UNIQUE INDEX set_spec_unique_constraint
+      ON ${database.defaultSchemaName}.set_lb (lower(set_spec));
+    </sql>
+    <sql>
+      CREATE UNIQUE INDEX name_unique_constraint
+      ON ${database.defaultSchemaName}.set_lb (lower(name));
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
@@ -94,6 +94,7 @@ class SetServiceImplTest extends AbstractSetTest {
   void setUp(VertxTestContext testContext) {
     setDao = new SetDaoImpl(postgresClientFactory);
     setService = new SetServiceImpl(setDao);
+//    testContext.completeNow();
     loadTestData(testContext);
   }
 
@@ -206,12 +207,13 @@ class SetServiceImplTest extends AbstractSetTest {
   }
 
   @Test
-  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedSetSpecValue(VertxTestContext testContext) {
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedSetSpecValue_CaseInsensitive(VertxTestContext testContext) {
     testContext.verify(() -> {
       setService.saveSet(POST_SET_ENTRY, TEST_TENANT_ID, TEST_USER_ID).onComplete(result -> {
         FolioSet setWithExistedSetSpecValue = result.result();
         setWithExistedSetSpecValue.setId(UUID.randomUUID().toString());
         setWithExistedSetSpecValue.setName("unique name");
+        setWithExistedSetSpecValue.setSetSpec(setWithExistedSetSpecValue.getSetSpec().toUpperCase());
         setService.saveSet(setWithExistedSetSpecValue, TEST_TENANT_ID, TEST_USER_ID).onFailure(throwable -> {
           assertTrue(throwable instanceof PgException);
           assertEquals(format(DUPLICATED_VALUE_DATABASE_ERROR_MSG, SET_SPEC_UNIQUE_CONSTRAINT), throwable.getMessage());
@@ -222,12 +224,13 @@ class SetServiceImplTest extends AbstractSetTest {
   }
 
   @Test
-  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedNameValue(VertxTestContext testContext) {
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedNameValue_CaseInsensitive(VertxTestContext testContext) {
     testContext.verify(() -> {
       setService.saveSet(POST_SET_ENTRY, TEST_TENANT_ID, TEST_USER_ID).onComplete(result -> {
         FolioSet setWithExistedNameValue = result.result();
         setWithExistedNameValue.setId(UUID.randomUUID().toString());
         setWithExistedNameValue.setSetSpec("unique setSpec");
+        setWithExistedNameValue.setName(setWithExistedNameValue.getName().toUpperCase());
         setService.saveSet(setWithExistedNameValue, TEST_TENANT_ID, TEST_USER_ID).onFailure(throwable -> {
           assertTrue(throwable instanceof PgException);
           assertEquals(format(DUPLICATED_VALUE_DATABASE_ERROR_MSG, NAME_UNIQUE_CONSTRAINT), throwable.getMessage());

--- a/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
@@ -94,7 +94,6 @@ class SetServiceImplTest extends AbstractSetTest {
   void setUp(VertxTestContext testContext) {
     setDao = new SetDaoImpl(postgresClientFactory);
     setService = new SetServiceImpl(setDao);
-//    testContext.completeNow();
     loadTestData(testContext);
   }
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhSetImplTest.java
@@ -371,7 +371,7 @@ class OaiPmhSetImplTest extends AbstractSetTest {
   }
 
   @Test
-  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedSetSpecValue(VertxTestContext testContext) {
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedSetSpecValue_CaseInsensitive(VertxTestContext testContext) {
     testContext.verify(() -> {
       RequestSpecification request = createBaseRequest(SET_PATH, ContentType.JSON).body(POST_SET_ENTRY);
       request.when()
@@ -380,8 +380,10 @@ class OaiPmhSetImplTest extends AbstractSetTest {
         .statusCode(201)
         .contentType(ContentType.JSON);
 
-      String oldValue = POST_SET_ENTRY.getName();
+      String oldNameValue = POST_SET_ENTRY.getName();
+      String oldSetSpecValue = POST_SET_ENTRY.getSetSpec();
       POST_SET_ENTRY.setName("unique value for name");
+      POST_SET_ENTRY.setSetSpec(oldSetSpecValue.toUpperCase());
 
       request = createBaseRequest(SET_PATH, ContentType.JSON).body(POST_SET_ENTRY);
       request.when()
@@ -389,14 +391,15 @@ class OaiPmhSetImplTest extends AbstractSetTest {
         .then()
         .statusCode(422)
         .contentType(ContentType.JSON)
-        .body("errors[0].message", equalTo(format(DUPLICATED_VALUE_USER_ERROR_MSG, "setSpec", POST_SET_ENTRY.getSetSpec())));
-      POST_SET_ENTRY.setName(oldValue);
+        .body("errors[0].message", equalTo(format(DUPLICATED_VALUE_USER_ERROR_MSG, "setSpec", POST_SET_ENTRY.getSetSpec().toLowerCase())));
+      POST_SET_ENTRY.setName(oldNameValue);
+      POST_SET_ENTRY.setSetSpec(oldSetSpecValue);
       testContext.completeNow();
     });
   }
 
   @Test
-  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedNameValue(VertxTestContext testContext) {
+  void shouldNotSaveItem_whenSaveItemWithAlreadyExistedNameValue_CaseInsensitive(VertxTestContext testContext) {
     testContext.verify(() -> {
       RequestSpecification request = createBaseRequest(SET_PATH, ContentType.JSON).body(POST_SET_ENTRY);
       request.when()
@@ -405,7 +408,9 @@ class OaiPmhSetImplTest extends AbstractSetTest {
         .statusCode(201)
         .contentType(ContentType.JSON);
 
-      String oldValue = POST_SET_ENTRY.getSetSpec();
+      String oldNameValue = POST_SET_ENTRY.getName();
+      String oldSetSpecValue = POST_SET_ENTRY.getSetSpec();
+      POST_SET_ENTRY.setName(oldNameValue.toUpperCase());
       POST_SET_ENTRY.setSetSpec("unique value for setSpec");
 
       request = createBaseRequest(SET_PATH, ContentType.JSON).body(POST_SET_ENTRY);
@@ -414,8 +419,9 @@ class OaiPmhSetImplTest extends AbstractSetTest {
         .then()
         .statusCode(422)
         .contentType(ContentType.JSON)
-        .body("errors[0].message", equalTo(format(DUPLICATED_VALUE_USER_ERROR_MSG, "name", POST_SET_ENTRY.getName())));
-      POST_SET_ENTRY.setSetSpec(oldValue);
+        .body("errors[0].message", equalTo(format(DUPLICATED_VALUE_USER_ERROR_MSG, "name", POST_SET_ENTRY.getName().toLowerCase())));
+      POST_SET_ENTRY.setName(oldNameValue);
+      POST_SET_ENTRY.setSetSpec(oldSetSpecValue);
       testContext.completeNow();
     });
   }


### PR DESCRIPTION
### PURPOSE
Modify unique constraints to consider the string case as well: qwe = QWE = QwE - only one of these values can be assigned to field under unique constraint.
Plus small fix regarding totalRecords field into set list response. Now totalRecords shows the records count into the whole system instead of the contained into response only. 