### PR TITLE
MODOAIPMH-230: Reference environment builds broken 2020-09-16 -- mod-oai-pmh?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ENV VERTICLE_FILE mod-oai-pmh-fat.jar
 
 # Set the location of the verticles
 ENV VERTICLE_HOME /usr/verticles
-ENV DOCKER_API_VERSION=1.39
 
 # Copy your fat jar to the container
 COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0-RC1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -96,8 +96,8 @@
     <sonar.exclusions>**/PropertyNameMapper.java</sonar.exclusions>
     <sonar.coverage.exclusions>**/ModTenantAPI.java</sonar.coverage.exclusions>
     <!-- Plugin versions -->
-    <aspectj.version>1.9.4</aspectj.version>
-    <raml-module-builder.version>30.2.4</raml-module-builder.version>
+    <aspectj.version>1.9.5</aspectj.version>
+    <raml-module-builder.version>31.0.2</raml-module-builder.version>
     <vertx.version>3.9.0</vertx.version>
     <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
     <apache-httpclient.version>4.5.11</apache-httpclient.version>


### PR DESCRIPTION

Removed implicit docker API version det (used before to fix env issue). Updated RAML version.