### PR TITLE
MODOAIPMH-216: Incorrect number of records returned by listrecords with resumption token for marc21 and marc21_withholdings

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -75,7 +75,7 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
         updatedBefore,
         null,
         request.getOffset(),
-        batchSize,
+        batchSize + 1,
         response -> {
           try {
             if (org.folio.rest.tools.client.Response.isSuccess(response.statusCode())) {

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -345,7 +345,7 @@ public abstract class AbstractHelper implements VerbHelper {
   }
 
   private JsonObject getLastInstance(JsonArray instances) {
-    return (JsonObject) instances.remove(instances.size() - 1);
+    return instances.getJsonObject(instances.size() - 1);
   }
 
   /**

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -322,9 +322,9 @@ public abstract class AbstractHelper implements VerbHelper {
       extraParams.put(OFFSET_PARAM, String.valueOf(newOffset));
       String nextRecordId;
       if (isDeletedRecordsEnabled(request)) {
-        nextRecordId = storageHelper.getId(getLastInstance(instances));
+        nextRecordId = storageHelper.getId(getAndRemoveLastInstance(instances));
       } else {
-        nextRecordId = storageHelper.getRecordId(getLastInstance(instances));
+        nextRecordId = storageHelper.getRecordId(getAndRemoveLastInstance(instances));
       }
       extraParams.put(NEXT_RECORD_ID_PARAM, nextRecordId);
       if (request.getUntil() == null) {
@@ -344,8 +344,8 @@ public abstract class AbstractHelper implements VerbHelper {
     return null;
   }
 
-  private JsonObject getLastInstance(JsonArray instances) {
-    return instances.getJsonObject(instances.size() - 1);
+  private JsonObject getAndRemoveLastInstance(JsonArray instances) {
+    return (JsonObject) instances.remove(instances.size() - 1);
   }
 
   /**


### PR DESCRIPTION
### PURPOSE
Fix issue with incorrect number of records returning by listrecords with resumption token for both marc21 and marc21_withholdings metadata formats
Jira: https://issues.folio.org/browse/MODOAIPMH-216