### PR TITLE
Add missing permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -19,7 +19,8 @@
             "configuration.entries.collection.get",
             "inventory-storage.oai-pmh-view.instances.collection.get",
             "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get",
-            "inventory-storage.oai-pmh-view.enrichedinstances.collection.post"
+            "inventory-storage.oai-pmh-view.enrichedinstances.collection.post",
+            "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose

Fix Edge module doesn't return the data, even if mod-oai-pmh does

## Root cause

This happened because diku_admin has all the necessary permissions, but the instituitional user diku, which is used when requests go through edge-oai-pmh, does not. This will be resolved in mod-oai-pmh 's module-descriptor.

Jira: https://issues.folio.org/browse/MODOAIPMH-245