### PR TITLE
MODOAIPMH-248: Release 3.1.3 with RMB 30.2.9, Vert.x 3.9.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+## 3.1.3 (Released)
+
+Fixes transaction bugs.
+
+* [MODOAIPMH-248](https://issues.folio.org/browse/MODOAIPMH-248) Upgrade RMB to 30.2.9:
+  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+    the following two patches
+  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
+  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
+  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
+    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778
+
 ## 3.1.2 (Released)
 
 This release includes fixing the NullPointerException on ListRecords with metdataPrefix=marc21_withholdings, fixing the incorrect displaying of item's "discovery suppressed" status into oai-pmh response and fixing the resumption token work.

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,16 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.6.0</version>
@@ -104,7 +114,7 @@
     <sonar.coverage.exclusions>**/ModTenantAPI.java</sonar.coverage.exclusions>
     <!-- Plugin versions -->
     <aspectj.version>1.9.4</aspectj.version>
-    <raml-module-builder.version>30.2.4</raml-module-builder.version>
+    <raml-module-builder.version>30.2.9</raml-module-builder.version>
     <vertx.version>3.9.4</vertx.version>
     <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
     <apache-httpclient.version>4.5.11</apache-httpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.6.0</version>
@@ -98,7 +105,7 @@
     <!-- Plugin versions -->
     <aspectj.version>1.9.4</aspectj.version>
     <raml-module-builder.version>30.2.4</raml-module-builder.version>
-    <vertx.version>3.9.0</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
     <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
     <apache-httpclient.version>4.5.11</apache-httpclient.version>
     <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
@@ -205,7 +212,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.1.3</version>
+  <version>3.1.4-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.1.3</tag>
+    <tag>v3.1.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.1.3-SNAPSHOT</version>
+  <version>3.1.3</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.1.0</tag>
+    <tag>v3.1.3</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
* [MODOAIPMH-248](https://issues.folio.org/browse/MODOAIPMH-248) Upgrade RMB to 30.2.9:
  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
    the following two patches
  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778