### PR TITLE
MODOAIPMH-250 Invalid number of identifiers are returned when get ListIdentifiers

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
@@ -77,7 +77,7 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
         updatedBefore,
         null,
         request.getOffset(),
-        batchSize,
+        batchSize+1,
         response -> response.bodyHandler(bh -> {
           try {
             final OAIPMH oaipmh = buildListIdentifiers(request, bh.toJsonObject());
@@ -88,20 +88,6 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
           }
         }));
 
-
-//      //region REMOVE IT
-//      // 2. Search for instances
-//       VertxCompletableFuture.from(ctx, httpClient.request(instanceEndpoint, request.getOkapiHeaders(), false))
-//        // 3. Verify response and build list of identifiers
-//        .thenApply(response -> buildListIdentifiers(request, response))
-//        // 4. Build final response to client (potentially blocking operation thus running on worker thread)
-//        .thenCompose(oai -> supplyBlockingAsync(ctx, () -> buildResponse(oai, request)))
-//        .thenAccept(promise::complete)
-//        .exceptionally(e -> {
-//          logger.error(GENERIC_ERROR, e);
-//          promise.fail(e);
-//          return null;
-//        });
     } catch (Exception e) {
       logger.error(GENERIC_ERROR, e);
       promise.fail(e);

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
@@ -77,7 +77,7 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
         updatedBefore,
         null,
         request.getOffset(),
-        batchSize+1,
+        batchSize + 1,
         response -> response.bodyHandler(bh -> {
           try {
             final OAIPMH oaipmh = buildListIdentifiers(request, bh.toJsonObject());


### PR DESCRIPTION
### PURPOSE
Fix issue with incorrect number of items being returned when perform ListIdentifiers request.

_Cannot be covered with unit tests cause number of returned records are mocked. 
Test coverage will be added in Karate integration test project._ 

Jira: https://issues.folio.org/browse/MODOAIPMH-250