### PR TITLE
MODOAIPMH-253: mod-oai-pmh-3.2.4- Honeysuckle Bugfix release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@
 This release includes bug fixes related to marc21_withholdings metadataPrefix and incorrect number of records being returned from ListIdentifiers request.
 
 * [MODOAIPMH-254](https://issues.folio.org/browse/MODOAIPMH-254) Initial load does not contain resumptionToken
-* [MODOAIPMH-250](https://issues.folio.org/browse/MODOAIPMH-254) Invalid number of identifiers are returned when get ListIdentifiers
-* [MODOAIPMH-252](https://issues.folio.org/browse/MODOAIPMH-254) Mod OAI_PMH container fail after call
+* [MODOAIPMH-250](https://issues.folio.org/browse/MODOAIPMH-250) Invalid number of identifiers are returned when get ListIdentifiers
+* [MODOAIPMH-252](https://issues.folio.org/browse/MODOAIPMH-252) Mod OAI_PMH container fail after call
 
 ## 3.2.3 (Released)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
-## 3.2.4 (Released)
+## 3.2.4 (Released) 2020-11-12
 
 This release includes bug fixes related to marc21_withholdings metadataPrefix and incorrect number of records being returned from ListIdentifiers request.
 
 * [MODOAIPMH-254](https://issues.folio.org/browse/MODOAIPMH-254) Initial load does not contain resumptionToken
 * [MODOAIPMH-250](https://issues.folio.org/browse/MODOAIPMH-250) Invalid number of identifiers are returned when get ListIdentifiers
 * [MODOAIPMH-252](https://issues.folio.org/browse/MODOAIPMH-252) Mod OAI_PMH container fail after call
+
+  [Full Changelog](https://github.com/folio-org/mod-data-export/compare/v3.2.3...v3.2.4)
 
 ## 3.2.3 (Released)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 3.2.4 (Released)
+
+This release includes bug fixes related to marc21_withholdings metadataPrefix and incorrect number of records being returned from ListIdentifiers request.
+
+* [MODOAIPMH-254](https://issues.folio.org/browse/MODOAIPMH-254) Initial load does not contain resumptionToken
+* [MODOAIPMH-250](https://issues.folio.org/browse/MODOAIPMH-254) Invalid number of identifiers are returned when get ListIdentifiers
+* [MODOAIPMH-252](https://issues.folio.org/browse/MODOAIPMH-254) Mod OAI_PMH container fail after call
+
 ## 3.2.3 (Released)
 
 This release includes updating RMB version up to 31.1.5 which fixing issues with database interaction.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The following schemas used:
  + OAI-PMH Schema: [OAI-PMH.xsd](http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#OAIPMHschema) for more dtails)
  + XML Schema for Dublin Core without qualification: [oai_dc.xsd](http://www.openarchives.org/OAI/2.0/oai_dc.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore) for more dtails)
  + MARC 21 XML Schema: [MARC21slim.xsd](http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd) (please refer to [MARC 21 XML Schema](http://www.loc.gov/standards/marcxml/) for more details)
-
+### Deployment requirements
+OAI-PMH is heavily loaded module and for correct work with big data set it requires to have as least 400 Mb of java heap and 1Gb for docker container memory.
 ### Configuration
 Configuration properties are intended to be retrieved from [mod-configuration](https://github.com/folio-org/mod-configuration/blob/master/README.md) module. System property values are used as a fallback.
 Configurations can be managed from the UI through the mod-configuration via folio settings.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following schemas used:
  + XML Schema for Dublin Core without qualification: [oai_dc.xsd](http://www.openarchives.org/OAI/2.0/oai_dc.xsd) (please refer to [OAI-PMH specification](http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore) for more dtails)
  + MARC 21 XML Schema: [MARC21slim.xsd](http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd) (please refer to [MARC 21 XML Schema](http://www.loc.gov/standards/marcxml/) for more details)
 ### Deployment requirements
-OAI-PMH is heavily loaded module and for correct work with big data set it requires to have as least 400 Mb of java heap and 1Gb for docker container memory.
+OAI-PMH is heavily loaded module and for correct work with big data set(approximately 4-5 millions records) it requires to have as least 400 Mb of java heap and 1Gb for docker container memory.
 ### Configuration
 Configuration properties are intended to be retrieved from [mod-configuration](https://github.com/folio-org/mod-configuration/blob/master/README.md) module. System property values are used as a fallback.
 Configurations can be managed from the UI through the mod-configuration via folio settings.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.2.4-SNAPSHOT</version>
+  <version>3.2.4</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.2.3</tag>
+    <tag>v3.2.4</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.2.4</version>
+  <version>3.2.5-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>


### PR DESCRIPTION
### PURPOSE
Release the mod-oai-pmh v3.2.4 which contains bug fixes for processing marc21_withholdings metadata format.

Jira: https://issues.folio.org/browse/MODOAIPMH-253