### PR TITLE
MODOAIPMH-240: Newest git update introduces build loop

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -54,8 +54,8 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
       final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
       final boolean suppressedRecordsSupport = getBooleanProperty(request.getOkapiHeaders(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
-      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false);
-      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true);
+      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false, true);
+      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true, true);
 
       int batchSize = Integer.parseInt(
         RepositoryConfigurationUtil.getProperty(request.getTenant(),

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -237,9 +237,9 @@ public abstract class AbstractHelper implements VerbHelper {
   }
 
   /**
-   * Adds difference between current time zone and UTC to date. Is used when date is going to be used for SRC client search criteria
-   * be the reason that SRC equates the date to UTC date which in result removes or adds time diff between current time zone and
-   * UTC. This prevents to invalid time borders requesting.
+   * Adds difference between the current time zone and UTC to 'date' param. Is used when 'date' is going to be used for SRC client
+   * search criteria by the reason that SRC equates the date to UTC date by subtracting the diff between current time zone and UTC
+   * which leads to invalid time borders requesting.
    *
    * @param date - date to be updated
    * @return updated date

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -1,5 +1,6 @@
 package org.folio.oaipmh.helpers;
 
+import static java.util.TimeZone.getDefault;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.oaipmh.Constants.BAD_DATESTAMP_FORMAT_ERROR;
@@ -33,14 +34,17 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
@@ -206,9 +210,10 @@ public abstract class AbstractHelper implements VerbHelper {
    * Parse a date from string and compensate one date or one second because in SRS the dates are non-inclusive.
    * @param dateTimeString - date/time supplied
    * @param shouldCompensateUntilDate = if the date is used as until parameter
+   * @param shouldEqualizeTimeBetweenZones whether the time should be updated by diff between current time zone and UTC
    * @return date that will be used to query SRS
    */
-  protected Date convertStringToDate(String dateTimeString, boolean shouldCompensateUntilDate) {
+  protected Date convertStringToDate(String dateTimeString, boolean shouldCompensateUntilDate, boolean shouldEqualizeTimeBetweenZones) {
     try {
       if (StringUtils.isEmpty(dateTimeString)) {
         return null;
@@ -221,12 +226,33 @@ public abstract class AbstractHelper implements VerbHelper {
           date = DateUtils.addSeconds(date, 1);
         }
       }
+      if(shouldEqualizeTimeBetweenZones) {
+        return addTimeDiffBetweenCurrentTimeZoneAndUTC(date);
+      }
       return date;
     } catch (DateTimeParseException | ParseException e) {
       logger.error(e);
       return null;
-
     }
+  }
+
+  /**
+   * Adds difference between current time zone and UTC to date. Is used when date is going to be used for SRC client search criteria
+   * be the reason that SRC equates the date to UTC date which in result removes or adds time diff between current time zone and
+   * UTC. This prevents to invalid time borders requesting.
+   *
+   * @param date - date to be updated
+   * @return updated date
+   */
+  private Date addTimeDiffBetweenCurrentTimeZoneAndUTC(Date date) {
+    int secondsDiff = ZoneId.systemDefault()
+      .getRules()
+      .getOffset(date.toInstant())
+      .getTotalSeconds();
+    Calendar calendar = Calendar.getInstance(TimeZone.getDefault());
+    calendar.setTime(date);
+    calendar.add(Calendar.SECOND, secondsDiff);
+    return calendar.getTime();
   }
 
   protected boolean validateIdentifier(Request request) {

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiIdentifiersHelper.java
@@ -57,8 +57,8 @@ public class GetOaiIdentifiersHelper extends AbstractHelper {
       final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
       final boolean suppressedRecordsSupport = getBooleanProperty(request.getOkapiHeaders(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
-      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false);
-      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true);
+      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false, true);
+      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true, true);
 
       int batchSize = Integer.parseInt(
         RepositoryConfigurationUtil.getProperty(request.getTenant(),

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
@@ -46,8 +46,8 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
       final SourceStorageSourceRecordsClient srsClient = new SourceStorageSourceRecordsClient(request.getOkapiUrl(),
         request.getTenant(), request.getOkapiToken());
 
-      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false);
-      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true);
+      final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false, true);
+      final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true, true);
 
       int batchSize = Integer.parseInt(
         RepositoryConfigurationUtil.getProperty(request.getTenant(),

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -477,11 +477,11 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
   private HttpClientRequest buildInventoryQuery(HttpClient httpClient, Request request) {
     Map<String, String> paramMap = new HashMap<>();
-    Date date = convertStringToDate(request.getFrom(), false);
+    Date date = convertStringToDate(request.getFrom(), false, false);
     if (date != null) {
       paramMap.put(START_DATE_PARAM_NAME, dateFormat.format(date));
     }
-    date = convertStringToDate(request.getUntil(), true);
+    date = convertStringToDate(request.getUntil(), true, false);
     if (date != null) {
       paramMap.put(END_DATE_PARAM_NAME, dateFormat.format(date));
     }


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-240

### PURPOSE
Resolve conflicts between time zones when running tests locally plus fixing by these changes the bug related to records requesting with invalid time borders.

The SRS client converts the date to UTC therefore the end date will be as next: passed date param - time differnce between env system time zone(STZ) and UTC.

### Approach
Before passing the dates to SRC client we add the time diff between current system time zone and UTC and further the same time diff will be subtracted by the SRC client back and by the end the same date which has been passed as param will be used as search criteria for records.
Example how it worked before: 
- STZ is +02:00
- before param which is passed equals to 2018-12-12T00:00:00z
- SRC client under the hood converts the 'before' to UTC, therefore it subtracts 2 hours of time zones difference from 'before' date(cuse UTC is 2 hours less then current time zone)
The 'before' param which is passed by SRC client was 2018-12-11T22:00:00z instead of expected 2018-12-12T00:00:00z

Example how it works now after fix:
- STZ is +02:00
- before param which is passed equals to 2018-12-12T00:00:00z
- the diff between time zones is added to 'before' param, 'before' param now which is passed to SRC client is 2018-12-12T02:00:00z (2 hours more)
- SRC client under the hood converts the 'before' to UTC, therefore it subtracts 2 hours of time zones difference from 'before' date(cuse UTC is 2 hours less then current time zone)
'before' param which is passed by SRC client now is 2018-12-12T00:00:00z which is expected.

The same is applicable for until param as well.
