### PR TITLE
MODOAIPMH-123: Datestamp in response doesn't correspond to time granularity

### DIFF
--- a/ramls/schemas/OAI-PMH.xsd
+++ b/ramls/schemas/OAI-PMH.xsd
@@ -168,7 +168,7 @@
     </annotation>
     <sequence>
       <element name="identifier" type="oai:identifierType"/>
-      <element name="datestamp" type="oai:UTCdatetimeType"/>
+      <element name="datestamp" type="string"/>
       <element name="setSpec" type="oai:setSpecType" minOccurs="0" maxOccurs="unbounded"/>
     </sequence>
     <attribute name="status" type="oai:statusType" use="optional"/>

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -14,8 +14,9 @@ public final class Constants {
    * Represents {@linkplain org.openarchives.oai._2.GranularityType#YYYY_MM_DD_THH_MM_SS_Z YYYY_MM_DD_THH_MM_SS_Z} granularity
    */
   public static final String ISO_DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  public static final String ISO_DATE_ONLY_PATTERN = "yyyy-MM-dd";
   public static final DateTimeFormatter ISO_UTC_DATE_TIME = DateTimeFormatter.ofPattern(ISO_DATE_TIME_PATTERN);
-  public static final DateTimeFormatter ISO_UTC_DATE_ONLY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  public static final DateTimeFormatter ISO_UTC_DATE_ONLY = DateTimeFormatter.ofPattern(ISO_DATE_ONLY_PATTERN);
 
   public static final String OKAPI_URL = "X-Okapi-Url";
   public static final String OKAPI_TENANT = "X-Okapi-Tenant";

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -193,7 +193,7 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
 
   private RecordType createRecord(Request request, String identifierPrefix, JsonObject instance, String identifierId) {
     RecordType record = new RecordType()
-      .withHeader(createHeader(instance)
+      .withHeader(createHeader(instance, request)
         .withIdentifier(getIdentifier(identifierPrefix, identifierId)));
     if (isDeletedRecordsEnabled(request) && storageHelper.isRecordMarkAsDeleted(instance)) {
       record.getHeader().setStatus(StatusType.DELETED);

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -1,57 +1,10 @@
 package org.folio.oaipmh.helpers;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.lang.time.DateUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.folio.oaipmh.MetadataPrefix;
-import org.folio.oaipmh.Request;
-import org.folio.oaipmh.ResponseConverter;
-import org.folio.oaipmh.helpers.response.ResponseHelper;
-import org.folio.oaipmh.helpers.storage.StorageHelper;
-import org.joda.time.DateTime;
-import org.openarchives.oai._2.GranularityType;
-import org.openarchives.oai._2.HeaderType;
-import org.openarchives.oai._2.MetadataType;
-import org.openarchives.oai._2.OAIPMH;
-import org.openarchives.oai._2.OAIPMHerrorType;
-import org.openarchives.oai._2.ResumptionTokenType;
-import org.openarchives.oai._2.SetType;
-import org.openarchives.oai._2.StatusType;
-
-import javax.ws.rs.core.Response;
-import java.math.BigInteger;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
-
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.oaipmh.Constants.BAD_DATESTAMP_FORMAT_ERROR;
 import static org.folio.oaipmh.Constants.CANNOT_DISSEMINATE_FORMAT_ERROR;
 import static org.folio.oaipmh.Constants.FROM_PARAM;
-import static org.folio.oaipmh.Constants.ISO_DATE_ONLY_PATTERN;
 import static org.folio.oaipmh.Constants.ISO_DATE_TIME_PATTERN;
 import static org.folio.oaipmh.Constants.ISO_UTC_DATE_ONLY;
 import static org.folio.oaipmh.Constants.ISO_UTC_DATE_TIME;
@@ -72,6 +25,53 @@ import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_ARGUMENT;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.BAD_RESUMPTION_TOKEN;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.CANNOT_DISSEMINATE_FORMAT;
 import static org.openarchives.oai._2.OAIPMHerrorcodeType.NO_RECORDS_MATCH;
+
+import java.math.BigInteger;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.oaipmh.MetadataPrefix;
+import org.folio.oaipmh.Request;
+import org.folio.oaipmh.ResponseConverter;
+import org.folio.oaipmh.helpers.response.ResponseHelper;
+import org.folio.oaipmh.helpers.storage.StorageHelper;
+import org.openarchives.oai._2.GranularityType;
+import org.openarchives.oai._2.HeaderType;
+import org.openarchives.oai._2.MetadataType;
+import org.openarchives.oai._2.OAIPMH;
+import org.openarchives.oai._2.OAIPMHerrorType;
+import org.openarchives.oai._2.ResumptionTokenType;
+import org.openarchives.oai._2.SetType;
+import org.openarchives.oai._2.StatusType;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Abstract helper implementation that provides some common methods.

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -15,6 +15,7 @@ import org.folio.oaipmh.Request;
 import org.folio.oaipmh.ResponseConverter;
 import org.folio.oaipmh.helpers.response.ResponseHelper;
 import org.folio.oaipmh.helpers.storage.StorageHelper;
+import org.joda.time.DateTime;
 import org.openarchives.oai._2.GranularityType;
 import org.openarchives.oai._2.HeaderType;
 import org.openarchives.oai._2.MetadataType;
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -49,6 +51,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.oaipmh.Constants.BAD_DATESTAMP_FORMAT_ERROR;
 import static org.folio.oaipmh.Constants.CANNOT_DISSEMINATE_FORMAT_ERROR;
 import static org.folio.oaipmh.Constants.FROM_PARAM;
+import static org.folio.oaipmh.Constants.ISO_DATE_ONLY_PATTERN;
 import static org.folio.oaipmh.Constants.ISO_DATE_TIME_PATTERN;
 import static org.folio.oaipmh.Constants.ISO_UTC_DATE_ONLY;
 import static org.folio.oaipmh.Constants.ISO_UTC_DATE_TIME;
@@ -203,8 +206,9 @@ public abstract class AbstractHelper implements VerbHelper {
 
   /**
    * Parse a date from string and compensate one date or one second because in SRS the dates are non-inclusive.
-   * @param dateTimeString - date/time supplied
-   * @param shouldCompensateUntilDate = if the date is used as until parameter
+   *
+   * @param dateTimeString                 - date/time supplied
+   * @param shouldCompensateUntilDate      = if the date is used as until parameter
    * @param shouldEqualizeTimeBetweenZones whether the time should be updated by diff between current time zone and UTC
    * @return date that will be used to query SRS
    */
@@ -214,14 +218,14 @@ public abstract class AbstractHelper implements VerbHelper {
         return null;
       }
       Date date = DateUtils.parseDate(dateTimeString, dateFormats);
-      if (shouldCompensateUntilDate){
-        if (dateTimeString.matches(DATE_ONLY_PATTERN)){
+      if (shouldCompensateUntilDate) {
+        if (dateTimeString.matches(DATE_ONLY_PATTERN)) {
           date = DateUtils.addDays(date, 1);
-        }else{
+        } else {
           date = DateUtils.addSeconds(date, 1);
         }
       }
-      if(shouldEqualizeTimeBetweenZones) {
+      if (shouldEqualizeTimeBetweenZones) {
         return addTimeDiffBetweenCurrentTimeZoneAndUTC(date);
       }
       return date;
@@ -271,10 +275,11 @@ public abstract class AbstractHelper implements VerbHelper {
    *
    * @param identifierPrefix oai-identifier prefix
    * @param instance         the instance item returned by storage service
+   * @param request          oai-pmh request
    * @return populated {@link HeaderType}
    */
-  protected HeaderType populateHeader(String identifierPrefix, JsonObject instance) {
-    return createHeader(instance)
+  protected HeaderType populateHeader(String identifierPrefix, JsonObject instance, Request request) {
+    return createHeader(instance, request)
       .withIdentifier(getIdentifier(identifierPrefix, instance));
   }
 
@@ -282,12 +287,22 @@ public abstract class AbstractHelper implements VerbHelper {
    * Creates {@link HeaderType} and Datestamp and Set
    *
    * @param instance the instance item returned by storage service
+   * @param request  oai-pmh request
    * @return populated {@link HeaderType}
    */
-  protected HeaderType createHeader(JsonObject instance) {
-    return new HeaderType()
-      .withDatestamp(getInstanceDate(instance))
-      .withSetSpecs("all");
+  protected HeaderType createHeader(JsonObject instance, Request request) {
+    HeaderType headerType = new HeaderType().withSetSpecs("all");
+    Instant instant = getInstanceDate(instance);
+    String date;
+    if (isDateOnlyGranularity(request)) {
+      instant = instant.truncatedTo(ChronoUnit.DAYS);
+      LocalDate time = LocalDate.ofInstant(instant, ZoneId.systemDefault());
+      date = ISO_UTC_DATE_ONLY.format(time);
+    } else {
+      LocalDateTime time = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+      date = ISO_UTC_DATE_TIME.format(time);
+    }
+    return headerType.withDatestamp(date);
   }
 
   /**
@@ -410,7 +425,7 @@ public abstract class AbstractHelper implements VerbHelper {
   }
 
   protected HeaderType addHeader(String identifierPrefix, Request request, JsonObject instance) {
-    HeaderType header = populateHeader(identifierPrefix, instance);
+    HeaderType header = populateHeader(identifierPrefix, instance, request);
     if (isDeletedRecordsEnabled(request) && storageHelper.isRecordMarkAsDeleted(instance)) {
       header.setStatus(StatusType.DELETED);
     }
@@ -419,27 +434,20 @@ public abstract class AbstractHelper implements VerbHelper {
 
   /**
    * Checks if request sequences can be resumed without losing records in case of partitioning the whole result set.
-   * <br/>
-   * The following state is an indicator that flow cannot be safely resumed:
-   * <li>No instances are returned</li>
-   * <li>Current total number of records is less than the previous one and the first
-   * record id does not match one stored in the resumptionToken</li>
-   * <br/>
-   * See <a href="https://issues.folio.org/browse/MODOAIPMH-10">MODOAIPMH-10</a> for more details.
    *
-   * @param request
-   * @param totalRecords
-   * @param instances
-   * @return
+   * @param request      oai-pmh request
+   * @param totalRecords records count into the system
+   * @param instances    instances from srs
+   * @return true if resumptionToken valid and request sequence can continue
    */
   protected boolean canResumeRequestSequence(Request request, Integer totalRecords, JsonArray instances) {
     Integer prevTotalRecords = request.getTotalRecords();
     boolean isDeletedRecords = isDeletedRecordsEnabled(request);
     int firstPosition = 0;
     return instances != null && instances.size() > 0
-        && (totalRecords >= prevTotalRecords || StringUtils.equals(request.getNextRecordId(),
-            isDeletedRecords ? storageHelper.getId(instances.getJsonObject(firstPosition))
-                : storageHelper.getRecordId(instances.getJsonObject(firstPosition))));
+      && (totalRecords >= prevTotalRecords || StringUtils.equals(request.getNextRecordId(),
+      isDeletedRecords ? storageHelper.getId(instances.getJsonObject(firstPosition))
+        : storageHelper.getRecordId(instances.getJsonObject(firstPosition))));
   }
 
   private List<String> getSupportedSetSpecs() {

--- a/src/main/java/org/folio/oaipmh/helpers/storage/AbstractStorageHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/storage/AbstractStorageHelper.java
@@ -1,18 +1,16 @@
 package org.folio.oaipmh.helpers.storage;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.lang.time.DateUtils;
-import org.folio.oaipmh.helpers.RepositoryConfigurationUtil;
+import static org.folio.oaipmh.Constants.TOTAL_RECORDS_PARAM;
 
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import static org.folio.oaipmh.Constants.TOTAL_RECORDS_PARAM;
+import org.apache.commons.lang.time.DateUtils;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 public abstract class AbstractStorageHelper implements StorageHelper {
   protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -38,7 +36,6 @@ public abstract class AbstractStorageHelper implements StorageHelper {
         instant = DateUtils.parseDateStrictly(lastModifiedDate, patterns).toInstant();
       } catch (ParseException parseException) {
         logger.error("Unable to parse the last modified date", parseException);
-        //TODO pass context here to get TG setting and in case of lowest value do truncatedTo days.
         return instant.truncatedTo(ChronoUnit.SECONDS);
       }
     }

--- a/src/main/java/org/folio/oaipmh/helpers/storage/AbstractStorageHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/storage/AbstractStorageHelper.java
@@ -1,9 +1,12 @@
 package org.folio.oaipmh.helpers.storage;
 
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang.time.DateUtils;
+import org.folio.oaipmh.helpers.RepositoryConfigurationUtil;
 
 import java.text.ParseException;
 import java.time.Instant;
@@ -35,6 +38,7 @@ public abstract class AbstractStorageHelper implements StorageHelper {
         instant = DateUtils.parseDateStrictly(lastModifiedDate, patterns).toInstant();
       } catch (ParseException parseException) {
         logger.error("Unable to parse the last modified date", parseException);
+        //TODO pass context here to get TG setting and in case of lowest value do truncatedTo days.
         return instant.truncatedTo(ChronoUnit.SECONDS);
       }
     }

--- a/src/main/java/org/folio/oaipmh/helpers/storage/StorageHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/storage/StorageHelper.java
@@ -80,7 +80,6 @@ public interface StorageHelper {
 
   JsonArray getRecordsItems(JsonObject entries);
 
-  @Deprecated
   String getId(JsonObject entry);
 
   /**

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -19,12 +19,10 @@ import static org.folio.oaipmh.helpers.RepositoryConfigurationUtil.getBooleanPro
 
 import java.lang.reflect.Field;
 import java.math.BigInteger;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Date;
@@ -39,7 +37,6 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
-import io.vertx.core.json.DecodeException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.oaipmh.Request;
 import org.folio.oaipmh.dao.PostgresClientFactory;
@@ -54,7 +51,6 @@ import org.folio.rest.jooq.tables.pojos.Instances;
 import org.folio.rest.jooq.tables.pojos.RequestMetadataLb;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.spring.SpringContextUtil;
-import org.openarchives.oai._2.HeaderType;
 import org.openarchives.oai._2.ListRecordsType;
 import org.openarchives.oai._2.OAIPMH;
 import org.openarchives.oai._2.OAIPMHerrorType;
@@ -73,6 +69,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -639,7 +636,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
               final JsonArray records = entries.getJsonArray("sourceRecords");
               records.stream()
                 .filter(Objects::nonNull)
-                .map(r -> (JsonObject) r)
+                .map(JsonObject.class::cast)
                 .forEach(jo -> result.put(jo.getJsonObject("externalIdsHolder").getString("instanceId"), jo));
             } else {
               logger.debug("Can't process response from SRS: {0}", bh.toString());

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -21,8 +21,6 @@ import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Date;
@@ -109,17 +107,6 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
   public static final MarcWithHoldingsRequestHelper INSTANCE = new MarcWithHoldingsRequestHelper();
 
   private InstancesService instancesService;
-
-  /**
-   * The dates returned by inventory storage service are in format "2018-09-19T02:52:08.873+0000".
-   * Using {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} and just in case 2 offsets "+HHmm" and "+HH:MM"
-   */
-  private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
-    .parseCaseInsensitive()
-    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    .optionalStart().appendOffset("+HH:MM", "Z").optionalEnd()
-    .optionalStart().appendOffset("+HHmm", "Z").optionalEnd()
-    .toFormatter();
 
   public static MarcWithHoldingsRequestHelper getInstance() {
     return INSTANCE;

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -428,19 +428,8 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
   private RecordType createRecord(Request request, JsonObject instance, String instanceId) {
     String identifierPrefix = request.getIdentifierPrefix();
     return new RecordType()
-      .withHeader(createHeader(instance)
+      .withHeader(createHeader(instance, request)
         .withIdentifier(getIdentifier(identifierPrefix, instanceId)));
-  }
-
-  @Override
-  protected HeaderType createHeader(JsonObject instance) {
-    String updatedDate = instance.getString("updatedDate");
-    Instant datetime = formatter.parse(updatedDate, Instant::from)
-      .truncatedTo(ChronoUnit.SECONDS);
-
-    return new HeaderType()
-      .withDatestamp(datetime)
-      .withSetSpecs("all");
   }
 
   private HttpClientRequest buildInventoryQuery(HttpClient httpClient, Request request) {

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -576,7 +576,7 @@ class OaiPmhImplTest {
     assertThat(getParamValue(params, TOTAL_RECORDS_PARAM), is(equalTo("100")));
     assertThat(getParamValue(params, NEXT_RECORD_ID_PARAM), is(equalTo("6506b79b-7702-48b2-9774-a1c538fdd34e")));
   }
-//kek
+  
   @ParameterizedTest
   @MethodSource("allMetadataPrefixesAndListVerbsProvider")
   void headersDatestampsShouldCorrespondToDateOnlyGranularitySetting(MetadataPrefix prefix, VerbType verb) {

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -89,8 +89,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -108,7 +108,6 @@ import org.folio.oaipmh.common.TestUtil;
 import org.folio.oaipmh.dao.PostgresClientFactory;
 import org.folio.oaipmh.service.InstancesService;
 import org.folio.rest.RestVerticle;
-import org.folio.rest.jooq.tables.pojos.Instances;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -197,6 +196,11 @@ class OaiPmhImplTest {
   private final Header tenantWithotConfigsHeader = new Header("X-Okapi-Tenant", "noConfigTenant");
   private final Header tokenHeader = new Header("X-Okapi-Token", "eyJhbGciOiJIUzI1NiJ9");
   private final Header okapiUrlHeader = new Header("X-Okapi-Url", "http://localhost:" + mockPort);
+
+  private static final String DATE_ONLY_REXEXP = "[\\d]{4}-[\\d]{2}-[\\d]{2}";
+  private static final String DATE_TIME_REGEXP = DATE_ONLY_REXEXP + "T[\\d]{2}:[\\d]{2}:[\\d]{2}Z";
+  private Pattern DATE_ONLY_PATTERN = Pattern.compile(DATE_ONLY_REXEXP);
+  private Pattern DATE_TIME_PATTERN = Pattern.compile(DATE_TIME_REGEXP);
 
   private Predicate<DataFieldType> suppressedDiscoveryMarcFieldPredicate;
   private Predicate<JAXBElement<ElementType>> suppressedDiscoveryDcFieldPredicate;
@@ -571,6 +575,87 @@ class OaiPmhImplTest {
     assertThat(getParamValue(params, OFFSET_PARAM), is(equalTo("10")));
     assertThat(getParamValue(params, TOTAL_RECORDS_PARAM), is(equalTo("100")));
     assertThat(getParamValue(params, NEXT_RECORD_ID_PARAM), is(equalTo("6506b79b-7702-48b2-9774-a1c538fdd34e")));
+  }
+//kek
+  @ParameterizedTest
+  @MethodSource("allMetadataPrefixesAndListVerbsProvider")
+  void headersDatestampsShouldCorrespondToDateOnlyGranularitySetting(MetadataPrefix prefix, VerbType verb) {
+    String timeGranularity = System.getProperty(REPOSITORY_TIME_GRANULARITY);
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, GranularityType.YYYY_MM_DD_THH_MM_SS_Z.value());
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, verb.value())
+      .param(FROM_PARAM, THREE_INSTANCES_DATE)
+      .param(METADATA_PREFIX_PARAM, prefix.getName());
+
+    OAIPMH oaipmh = verify200WithXml(request, verb);
+    verifyHeaderDateStamp(oaipmh, verb, GranularityType.YYYY_MM_DD_THH_MM_SS_Z.value());
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, timeGranularity);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allMetadataPrefixesAndListVerbsProvider")
+  void headersDatestampsShouldCorrespondToDateTimeGranularitySetting(MetadataPrefix prefix, VerbType verb) {
+    String timeGranularity = System.getProperty(REPOSITORY_TIME_GRANULARITY);
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, GranularityType.YYYY_MM_DD.value());
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, verb.value())
+      .param(FROM_PARAM, THREE_INSTANCES_DATE)
+      .param(METADATA_PREFIX_PARAM, prefix.getName());
+
+    OAIPMH oaipmh = verify200WithXml(request, verb);
+    verifyHeaderDateStamp(oaipmh, verb, GranularityType.YYYY_MM_DD.value());
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, timeGranularity);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allMetadataPrefixesAndGranularityTypesProvider")
+  void headerDatestampOfGetRecordVerbShouldCorrespondToGranularitySetting(MetadataPrefix prefix, GranularityType granularityType) {
+    String timeGranularity = System.getProperty(REPOSITORY_TIME_GRANULARITY);
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, granularityType.value());
+
+    String identifier = IDENTIFIER_PREFIX + OkapiMockServer.EXISTING_IDENTIFIER;
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, GET_RECORD.value())
+      .param(IDENTIFIER_PARAM, identifier)
+      .param(METADATA_PREFIX_PARAM, prefix.getName());
+
+    OAIPMH oaipmh = verify200WithXml(request, GET_RECORD);
+    verifyHeaderDateStamp(oaipmh, GET_RECORD, granularityType.value());
+    System.setProperty(REPOSITORY_TIME_GRANULARITY, timeGranularity);
+  }
+
+  private void verifyHeaderDateStamp(OAIPMH oaipmh, VerbType verbType, String timeGranularity) {
+    String verb = verbType.value();
+    if (verb.equals(LIST_RECORDS.value())) {
+      oaipmh.getListRecords().getRecords().stream()
+        .map(RecordType::getHeader)
+        .map(HeaderType::getDatestamp)
+        .forEach(headerDateStamp -> verifyHeaderDateStamp(headerDateStamp, timeGranularity));
+    } else if (verb.equals(LIST_IDENTIFIERS.value())) {
+      oaipmh.getListIdentifiers().getHeaders().stream()
+        .map(HeaderType::getDatestamp)
+        .forEach(headerDateStamp -> verifyHeaderDateStamp(headerDateStamp, timeGranularity));
+    } else if (verb.equals(GET_RECORD.value())) {
+      String datestamp = oaipmh.getGetRecord()
+        .getRecord()
+        .getHeader()
+        .getDatestamp();
+      verifyHeaderDateStamp(datestamp, timeGranularity);
+    }
+  }
+
+  private void verifyHeaderDateStamp(String datestamp, String timeGranularity) {
+    if (timeGranularity.equals(GranularityType.YYYY_MM_DD.value())) {
+      assertTrue(DATE_ONLY_PATTERN.matcher(datestamp).matches());
+    } else {
+      assertTrue(DATE_TIME_PATTERN.matcher(datestamp).matches());
+    }
   }
 
   @ParameterizedTest
@@ -1675,6 +1760,16 @@ class OaiPmhImplTest {
     for (MetadataPrefix prefix : MetadataPrefix.values()) {
       for (VerbType verb : LIST_VERBS) {
           builder.add(Arguments.arguments(prefix, verb));
+      }
+    }
+    return builder.build();
+  }
+
+  private static Stream<Arguments> allMetadataPrefixesAndGranularityTypesProvider() {
+    Stream.Builder<Arguments> builder = Stream.builder();
+    for (MetadataPrefix prefix : MetadataPrefix.values()) {
+      for (GranularityType granularity : GranularityType.values()) {
+        builder.add(Arguments.arguments(prefix, granularity));
       }
     }
     return builder.build();


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-123
### PURPOSE
Make header datestamps be affected by time granularity setting, i.e. header datestamp should match time granularity format.

### APPROACH
Set date to header type in a particular date format.