### PR TITLE
MODOAIPMH-274: Retrieving loaded instance ids doesn't take the request id into account.

### DIFF
--- a/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
+++ b/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
@@ -32,9 +32,9 @@ public interface InstancesDao {
   Future<Boolean> deleteRequestMetadataByRequestId(String requestId, String tenantId);
 
   /**
-   * Deletes batch of instances by provided ids list.
+   * Deletes batch of instances by provided ids list and request id.
    */
-  Future<Boolean> deleteInstancesById(List<String> instIds, String tenantId);
+  Future<Boolean> deleteInstancesById(List<String> instIds, String requestId, String tenantId);
 
   /**
    * Saves batch of instances.

--- a/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
+++ b/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
@@ -42,7 +42,7 @@ public interface InstancesDao {
   Future<Void> saveInstances(List<Instances> instances, String tenantId);
 
   /**
-   * Retrieves instances by offset and limit.
+   * Retrieves instances by limit and request id.
    */
-  Future<List<Instances>> getInstancesList(int offset, int limit, String tenantId);
+  Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
 }

--- a/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
+++ b/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
@@ -148,10 +148,10 @@ public class InstancesDaoImpl implements InstancesDao {
   }
 
   @Override
-  public Future<List<Instances>> getInstancesList(int offset, int limit, String tenantId) {
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId) {
     return getQueryExecutor(tenantId).transaction(queryExecutor -> queryExecutor
-      .query(dslContext -> dslContext.selectFrom(INSTANCES)
-        .offset(offset)
+      .query(dslContext -> dslContext.selectFrom(INSTANCES).where(INSTANCES.REQUEST_ID.eq(UUID.fromString(requestId)))
+        .orderBy(INSTANCES.INSTANCE_ID)
         .limit(limit))
       .map(this::queryResultToInstancesList));
   }

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -17,26 +17,24 @@ import static org.folio.oaipmh.Constants.REQUEST_ID_PARAM;
 import static org.folio.oaipmh.Constants.UNTIL_PARAM;
 import static org.folio.oaipmh.helpers.RepositoryConfigurationUtil.getBooleanProperty;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.Maps;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.RequestOptions;
-import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.parsetools.JsonEvent;
-import io.vertx.core.parsetools.JsonParser;
-import io.vertx.core.parsetools.impl.JsonParserImpl;
-import io.vertx.pgclient.PgPool;
-import io.vertx.sqlclient.impl.Connection;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,22 +60,26 @@ import org.openarchives.oai._2.StatusType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ReflectionUtils;
 
-import javax.ws.rs.core.Response;
-import java.lang.reflect.Field;
-import java.math.BigInteger;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import com.google.common.collect.Maps;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.JsonEvent;
+import io.vertx.core.parsetools.JsonParser;
+import io.vertx.core.parsetools.impl.JsonParserImpl;
+import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.impl.Connection;
 
 
 public class MarcWithHoldingsRequestHelper extends AbstractHelper {
@@ -603,7 +605,6 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     }
   }
 
-  //fix vertx json to jooq JSON mapping
   private Promise<Void> saveInstancesIds(List<JsonEvent> instances, Request request, String requestId, BatchStreamWrapper databaseWriteStream) {
     Promise<Void> promise = Promise.promise();
     List<Instances> instancesList = toInstancesList(instances, UUID.fromString(requestId));

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -219,7 +219,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
           List<String> instanceIds = instancesWithoutLast.stream()
             .map(e -> e.getString(INSTANCE_ID_FIELD_NAME))
             .collect(toList());
-          instancesService.deleteInstancesById(instanceIds, request.getTenant())
+          instancesService.deleteInstancesById(instanceIds, requestId, request.getTenant())
             .onComplete(r -> oaiPmhResponsePromise.complete(result)); //need remove this close client maybe
         }).onFailure(e -> handleException(oaiPmhResponsePromise, e)));
         srsResponse.onFailure(t -> handleException(oaiPmhResponsePromise, t));

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -316,7 +316,9 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
     RequestOptions requestOptions = new RequestOptions();
     requestOptions.setAbsoluteURI(request.getOkapiUrl() + INVENTORY_INSTANCES_ENDPOINT);
-    requestOptions.setSsl(true);
+    if(request.getOkapiUrl().contains("https")) {
+      requestOptions.setSsl(true);
+    }
     requestOptions.setMethod(HttpMethod.POST);
     return httpClient.request(requestOptions);
   }
@@ -472,7 +474,9 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     //TODO make 2 ways with port and without
     RequestOptions requestOptions = new RequestOptions();
     requestOptions.setAbsoluteURI(request.getOkapiUrl() + inventoryQuery);
-    requestOptions.setSsl(true);
+    if(request.getOkapiUrl().contains("https")) {
+      requestOptions.setSsl(true);
+    }
     requestOptions.setMethod(HttpMethod.GET);
     return httpClient.request(requestOptions);
 

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -28,6 +28,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -312,7 +313,12 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     List<String> okapiUrlParts = Splitter.on(":").splitToList(request.getOkapiUrl());
     String okapiHost = okapiUrlParts.get(1).replace("//","");
     Integer okapiPort = Integer.valueOf(okapiUrlParts.get(2));
-    return httpClient.request(HttpMethod.POST, okapiPort, okapiHost, INVENTORY_INSTANCES_ENDPOINT);
+
+    RequestOptions requestOptions = new RequestOptions();
+    requestOptions.setAbsoluteURI(request.getOkapiUrl() + INVENTORY_INSTANCES_ENDPOINT);
+    requestOptions.setSsl(true);
+    requestOptions.setMethod(HttpMethod.POST);
+    return httpClient.request(requestOptions);
   }
 
   private void enrichDiscoverySuppressed(JsonObject itemsandholdingsfields, JsonObject instance) {
@@ -463,8 +469,14 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     String okapiHost = okapiUrlParts.get(1).replace("//","");
     Integer okapiPort = Integer.valueOf(okapiUrlParts.get(2));
     logger.info("Sending request to : " + inventoryQuery);
+    //TODO make 2 ways with port and without
+    RequestOptions requestOptions = new RequestOptions();
+    requestOptions.setAbsoluteURI(request.getOkapiUrl() + inventoryQuery);
+    requestOptions.setSsl(true);
+    requestOptions.setMethod(HttpMethod.GET);
+    return httpClient.request(requestOptions);
 
-    return  httpClient.request(HttpMethod.GET, okapiPort, okapiHost, inventoryQuery);
+//    return  httpClient.request(HttpMethod.GET, okapiPort, okapiHost, inventoryQuery);
   }
 
   private void appendHeadersAndSetTimeout(Request request, HttpClientRequest httpClientRequest) {

--- a/src/main/java/org/folio/oaipmh/service/InstancesService.java
+++ b/src/main/java/org/folio/oaipmh/service/InstancesService.java
@@ -2,7 +2,6 @@ package org.folio.oaipmh.service;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jooq.tables.pojos.Instances;
 import org.folio.rest.jooq.tables.pojos.RequestMetadataLb;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/folio/oaipmh/service/InstancesService.java
+++ b/src/main/java/org/folio/oaipmh/service/InstancesService.java
@@ -2,6 +2,7 @@ package org.folio.oaipmh.service;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jooq.tables.pojos.Instances;
 import org.folio.rest.jooq.tables.pojos.RequestMetadataLb;
 import org.springframework.stereotype.Service;
@@ -45,8 +46,8 @@ public interface InstancesService {
   Future<Void> saveInstances(List<Instances> instances, String tenantId);
 
   /**
-   * Retrieves instances by offset and limit.
+   * Retrieves instances by limit and request id.
    */
-  Future<List<Instances>> getInstancesList(int offset, int limit, String tenantId);
+  Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
 
 }

--- a/src/main/java/org/folio/oaipmh/service/InstancesService.java
+++ b/src/main/java/org/folio/oaipmh/service/InstancesService.java
@@ -35,9 +35,9 @@ public interface InstancesService {
   Future<Boolean> deleteRequestMetadataByRequestId(String requestId, String tenantId);
 
   /**
-   * Deletes batch of instances by provided ids list.
+   * Deletes batch of instances by provided ids list and request id.
    */
-  Future<Boolean> deleteInstancesById(List<String> instIds, String tenantId);
+  Future<Boolean> deleteInstancesById(List<String> instIds, String requestId, String tenantId);
 
   /**
    * Saves batch of instances.

--- a/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
+++ b/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
@@ -47,10 +47,11 @@ public class InstancesServiceImpl implements InstancesService {
         } else {
           promise.complete(Collections.emptyList());
         }
-      }).onFailure(th -> {
-      logger.error(th.getMessage());
-      promise.fail(th);
-    });
+      })
+      .onFailure(th -> {
+        logger.error(th.getMessage());
+        promise.fail(th);
+      });
     return promise.future();
   }
 
@@ -61,7 +62,7 @@ public class InstancesServiceImpl implements InstancesService {
 
   @Override
   public Future<RequestMetadataLb> updateRequestMetadataByRequestId(String requestId, RequestMetadataLb requestMetadataLb,
-                                                                    String tenantId) {
+      String tenantId) {
     return instancesDao.updateRequestMetadataByRequestId(requestId, requestMetadataLb, tenantId);
   }
 
@@ -71,8 +72,8 @@ public class InstancesServiceImpl implements InstancesService {
   }
 
   @Override
-  public Future<Boolean> deleteInstancesById(List<String> instIds, String tenantId) {
-    return instancesDao.deleteInstancesById(instIds, tenantId);
+  public Future<Boolean> deleteInstancesById(List<String> instIds, String requestId, String tenantId) {
+    return instancesDao.deleteInstancesById(instIds, requestId, tenantId);
   }
 
   @Override

--- a/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
+++ b/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
@@ -1,7 +1,11 @@
 package org.folio.oaipmh.service.impl;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.oaipmh.dao.InstancesDao;
@@ -12,11 +16,8 @@ import org.folio.rest.jooq.tables.pojos.RequestMetadataLb;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 @Service
 public class InstancesServiceImpl implements InstancesService {
@@ -80,8 +81,8 @@ public class InstancesServiceImpl implements InstancesService {
   }
 
   @Override
-  public Future<List<Instances>> getInstancesList(int offset, int limit, String tenantId) {
-    return instancesDao.getInstancesList(offset, limit, tenantId);
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId) {
+    return instancesDao.getInstancesList(limit, requestId, tenantId);
   }
 
   @Autowired

--- a/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
+++ b/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
@@ -104,16 +104,4 @@ public abstract class AbstractInstancesTest {
 
   protected abstract InstancesDao getInstancesDao();
 
-//  private void cleanInstances(VertxTestContext testContext) {
-//    List<Future> list = new ArrayList<>();
-//    getInstancesDao().getExpiredRequestIds(OAI_TEST_TENANT, 0)
-//      .onSuccess(requestIds -> {
-//        requestIds.forEach(id -> list.add(getInstancesDao().deleteRequestMetadataByRequestId(id, OAI_TEST_TENANT)));
-//      })
-//      .onFailure(testContext::failNow);
-//    GenericCompositeFuture.all(list)
-//      .onSuccess(v -> testContext.completeNow())
-//      .onFailure(testContext::failNow);
-//  }
-
 }

--- a/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
+++ b/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
@@ -25,26 +25,35 @@ public abstract class AbstractInstancesTest {
 
   protected static final String COMMON_JSON = "{\"instanceId\": \"00000000-0000-4000-a000-000000000000\", \"source\": \"FOLIO\", \"updatedDate\": \"2020-06-15T11:07:48.563Z\",  \"deleted\": \"false\",  \"suppressFromDiscovery\": \"false\"}";
 
-  protected static final String EXPIRED_REQUEST_ID = UUID.randomUUID().toString();
-  protected static final String REQUEST_ID = UUID.randomUUID().toString();
-  protected static final String NON_EXISTENT_REQUEST_ID = UUID.randomUUID().toString();
+  protected static final String EXPIRED_REQUEST_ID = UUID.randomUUID()
+    .toString();
+  protected static final String REQUEST_ID = UUID.randomUUID()
+    .toString();
+  protected static final String NON_EXISTENT_REQUEST_ID = UUID.randomUUID()
+    .toString();
 
-  protected static final String EXPIRED_INSTANCE_ID = UUID.randomUUID().toString();
-  protected static final String INSTANCE_ID = UUID.randomUUID().toString();
-  protected static final String NON_EXISTENT_INSTANCE_ID = UUID.randomUUID().toString();
+  protected static final String EXPIRED_INSTANCE_ID = UUID.randomUUID()
+    .toString();
+  protected static final String INSTANCE_ID = UUID.randomUUID()
+    .toString();
+  protected static final String NON_EXISTENT_INSTANCE_ID = UUID.randomUUID()
+    .toString();
 
   protected List<String> requestIds = List.of(EXPIRED_REQUEST_ID, REQUEST_ID);
   protected List<String> instancesIds = List.of(EXPIRED_INSTANCE_ID, INSTANCE_ID);
   protected List<String> nonExistentInstancesIds = List.of(NON_EXISTENT_INSTANCE_ID);
 
   protected static final OffsetDateTime notExpiredDate = OffsetDateTime.now(ZoneId.systemDefault());
-  protected static final OffsetDateTime expiredDate = OffsetDateTime.now(ZoneId.systemDefault()).minusSeconds(INSTANCES_EXPIRATION_TIME_IN_SECONDS);
+  protected static final OffsetDateTime expiredDate = OffsetDateTime.now(ZoneId.systemDefault())
+    .minusSeconds(INSTANCES_EXPIRATION_TIME_IN_SECONDS);
 
-  protected static final RequestMetadataLb expiredRequestMetadata = new RequestMetadataLb().setRequestId(UUID.fromString(EXPIRED_REQUEST_ID))
+  protected static final RequestMetadataLb expiredRequestMetadata = new RequestMetadataLb()
+    .setRequestId(UUID.fromString(EXPIRED_REQUEST_ID))
     .setLastUpdatedDate(expiredDate);
   protected static final RequestMetadataLb requestMetadata = new RequestMetadataLb().setRequestId(UUID.fromString(REQUEST_ID))
     .setLastUpdatedDate(notExpiredDate);
-  protected static final RequestMetadataLb nonExistentRequestMetadata = new RequestMetadataLb().setRequestId(UUID.fromString(NON_EXISTENT_REQUEST_ID))
+  protected static final RequestMetadataLb nonExistentRequestMetadata = new RequestMetadataLb()
+    .setRequestId(UUID.fromString(NON_EXISTENT_REQUEST_ID))
     .setLastUpdatedDate(notExpiredDate);
 
   protected static final Instances instance_1 = new Instances().setInstanceId(UUID.fromString(EXPIRED_INSTANCE_ID))
@@ -60,13 +69,14 @@ public abstract class AbstractInstancesTest {
   @BeforeEach
   void setup(VertxTestContext testContext) {
     List<Future> saveRequestMetadataFutures = new ArrayList<>();
-    requestMetadataList.forEach(elem -> saveRequestMetadataFutures.add(getInstancesDao().saveRequestMetadata(elem, OAI_TEST_TENANT)));
+    requestMetadataList
+      .forEach(elem -> saveRequestMetadataFutures.add(getInstancesDao().saveRequestMetadata(elem, OAI_TEST_TENANT)));
 
     GenericCompositeFuture.all(saveRequestMetadataFutures)
       .onSuccess(v -> getInstancesDao().saveInstances(instancesList, OAI_TEST_TENANT)
         .onSuccess(e -> testContext.completeNow())
-        .onFailure(testContext::failNow)
-      ).onFailure(testContext::failNow);
+        .onFailure(testContext::failNow))
+      .onFailure(testContext::failNow);
   }
 
   @AfterEach
@@ -93,5 +103,17 @@ public abstract class AbstractInstancesTest {
   }
 
   protected abstract InstancesDao getInstancesDao();
+
+//  private void cleanInstances(VertxTestContext testContext) {
+//    List<Future> list = new ArrayList<>();
+//    getInstancesDao().getExpiredRequestIds(OAI_TEST_TENANT, 0)
+//      .onSuccess(requestIds -> {
+//        requestIds.forEach(id -> list.add(getInstancesDao().deleteRequestMetadataByRequestId(id, OAI_TEST_TENANT)));
+//      })
+//      .onFailure(testContext::failNow);
+//    GenericCompositeFuture.all(list)
+//      .onSuccess(v -> testContext.completeNow())
+//      .onFailure(testContext::failNow);
+//  }
 
 }

--- a/src/test/java/org/folio/oaipmh/service/impl/InstancesServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/InstancesServiceImplTest.java
@@ -1,9 +1,18 @@
 package org.folio.oaipmh.service.impl;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
+import static org.folio.rest.impl.OkapiMockServer.OAI_TEST_TENANT;
+import static org.folio.rest.jooq.Tables.INSTANCES;
+import static org.folio.rest.jooq.Tables.REQUEST_METADATA_LB;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import javax.ws.rs.NotFoundException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.config.ApplicationConfig;
@@ -24,18 +33,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.ws.rs.NotFoundException;
-import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.folio.rest.impl.OkapiMockServer.OAI_TEST_TENANT;
-import static org.folio.rest.jooq.Tables.INSTANCES;
-import static org.folio.rest.jooq.Tables.REQUEST_METADATA_LB;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(VertxExtension.class)
@@ -48,12 +49,6 @@ class InstancesServiceImplTest extends AbstractInstancesTest {
 
   private static final int EXPIRED_REQUEST_IDS_EMPTY_LIST_TIME = 2000;
   private static final int ZERO_EXPIRED_INSTANCES_TIME = INSTANCES_EXPIRATION_TIME_IN_SECONDS * 2;
-
-  private static final String REQUEST_ID_DAO_ERROR = "c75afb20-1812-45ab-badf-16d569502a99";
-  private static final String REQUEST_ID_DAO_DB_SUCCESS_RESPONSE = "c86afb20-1812-45ab-badf-16d569502a99";
-
-  private static List<String> validRequestIds = Collections.singletonList(REQUEST_ID_DAO_DB_SUCCESS_RESPONSE);
-  private static List<String> daoErrorRequestId = Collections.singletonList(REQUEST_ID_DAO_ERROR);
 
   @Autowired
   private InstancesDao instancesDao;
@@ -212,7 +207,7 @@ class InstancesServiceImplTest extends AbstractInstancesTest {
 
   @Test
   void shouldReturnSucceedFutureWithInstancesList_whenGetInstancesListAndSomeInstancesExist(VertxTestContext testContext) {
-    testContext.verify(() -> instancesService.getInstancesList(0, 100, OAI_TEST_TENANT)
+    testContext.verify(() -> instancesService.getInstancesList(100,  REQUEST_ID, OAI_TEST_TENANT)
       .onComplete(testContext.succeeding(instancesList -> {
         assertFalse(instancesList.isEmpty());
         testContext.completeNow();
@@ -221,7 +216,7 @@ class InstancesServiceImplTest extends AbstractInstancesTest {
 
   @Test
   void shouldReturnSucceedFutureWithEmptyList_whenGetInstancesListAndThereNoAnyInstancesExist(VertxTestContext testContext) {
-    testContext.verify(() -> cleanData().compose(res -> instancesService.getInstancesList(0, 100, OAI_TEST_TENANT))
+    testContext.verify(() -> cleanData().compose(res -> instancesService.getInstancesList(100, REQUEST_ID, OAI_TEST_TENANT))
       .onComplete(testContext.succeeding(instancesList -> {
         assertTrue(instancesList.isEmpty());
         testContext.completeNow();

--- a/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
+++ b/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
@@ -113,7 +113,7 @@ class CleanUpJobTest extends AbstractInstancesTest {
   }
 
   private void verifyExpiredInstancesHasBeenCleared(VertxTestContext testContext) {
-    instancesDao.getInstancesList(0, 100, OAI_TEST_TENANT).onSuccess(instances -> {
+    instancesDao.getInstancesList(100, EXPIRED_REQUEST_ID, OAI_TEST_TENANT).onSuccess(instances -> {
       List<String> instancesIds = instances.stream().map(Instances::getInstanceId).map(UUID::toString).collect(Collectors.toList());
       assertFalse(instancesIds.contains(EXPIRED_INSTANCE_ID));
       testContext.completeNow();


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-274

### PURPOSE
When there are several initial-loads runs simultaneously, then when the first of them will finish then it is going to pick up the first batch of instance ids without considering the current request-id which will lead to retrieving mixed instance ids which can relate to different request ids(harvesters) or duplicated ids by the reason that it can retrieve the same instance ids which hold different request ids, such duplicates lead to an error.
 ### APPROACH
Add request id as param for both getInstances and deleteInstances methods.