### PR TITLE
MODOAIPMH-272: Release the mod-oai-pmh v3.2.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+## 3.2.5 (Released) 2020-12-30
+
+This release mainly contains bug fixes related to marc21_withholdings request and upgrade of RMB up to 32.0.0 .
+
+* [MODOAIPMH-274](https://issues.folio.org/browse/MODOAIPMH-274) Retrieving loaded instance ids doesn't take the request id into account.
+* [MODOAIPMH-273](https://issues.folio.org/browse/MODOAIPMH-273) Missing holdings/item fields in ListRecords response with marc21_whitholdings
+* [MODOAIPMH-271](https://issues.folio.org/browse/MODOAIPMH-271) Create a database migration script to enrich new oai-pmh tables.
+* [MODOAIPMH-266](https://issues.folio.org/browse/MODOAIPMH-266) Upgrade to RMB 32
+* [MODOAIPMH-265](https://issues.folio.org/browse/MODOAIPMH-265) Refactor the dao layer and update the readme with initial-load description
+* [MODOAIPMH-259](https://issues.folio.org/browse/MODOAIPMH-259) HTML encoded entities in records make the OAI-PMH requests crash
+* [MODOAIPMH-258](https://issues.folio.org/browse/MODOAIPMH-258) Clean data for outdated requests from instance table
+* [MODOAIPMH-240](https://issues.folio.org/browse/MODOAIPMH-240) Newest git update introduces build loop
+* [MODOAIPMH-123](https://issues.folio.org/browse/MODOAIPMH-123) Datestamp in response doesn't correspond to time granularity
+* [MODOAIPMH-71](https://issues.folio.org/browse/MODOAIPMH-71) Handle json parsing exceptions gracefully
+
+  [Full Changelog](https://github.com/folio-org/mod-data-export/compare/v3.2.4...v3.2.5)
+
 ## 3.2.4 (Released) 2020-11-12
 
 This release includes bug fixes related to marc21_withholdings metadataPrefix and incorrect number of records being returned from ListIdentifiers request.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.2.5-SNAPSHOT</version>
+  <version>3.2.5</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.2.4</tag>
+    <tag>v3.2.5</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.2.5</version>
+  <version>3.2.6-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.2.5</tag>
+    <tag>v3.2.4</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.2.6-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.2.5-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-272

### PURPOSE
Release the module. As well the 3.3.0 version of the next development iteration specified since there the same version was accidentally deployed to testing/snapshot environments and we should keep the same version within pom in order to have the latest changes being redeployed at environments.