### PR TITLE
Fix DB pool conflicts

### DIFF
--- a/src/main/java/org/folio/oaipmh/dao/PostgresClientFactory.java
+++ b/src/main/java/org/folio/oaipmh/dao/PostgresClientFactory.java
@@ -1,6 +1,8 @@
 package org.folio.oaipmh.dao;
 
 import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -8,6 +10,8 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+
+import org.folio.oaipmh.Request;
 import org.folio.rest.persist.PostgresClient;
 import org.jooq.Configuration;
 import org.jooq.SQLDialect;
@@ -36,6 +40,11 @@ public class PostgresClientFactory {
 
   private static final int POOL_SIZE = 20;
 
+  /**
+   * Such field is temporary solution which is used to allow resetting the pool in tests.
+   * In future the {@link org.folio.oaipmh.processors.MarcWithHoldingsRequestHelper#getNextBatch(String, Request, int, Promise, Context, Long)}
+   * should be canceled when response with failure already responded.
+   */
   private static boolean shouldResetPool = false;
 
   private static final Map<String, PgPool> POOL_CACHE = new HashMap<>();

--- a/src/test/java/org/folio/oaipmh/service/impl/InstancesServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/InstancesServiceImplTest.java
@@ -58,6 +58,7 @@ class InstancesServiceImplTest extends AbstractInstancesTest {
 
   @BeforeAll
   void setUpClass(Vertx vertx, VertxTestContext testContext) throws Exception {
+    PostgresClientFactory.setShouldResetPool(true);
     logger.info("Test setup starting for " + TestUtil.getModuleId());
     PostgresClient.getInstance(vertx)
       .startEmbeddedPostgres();

--- a/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
+++ b/src/test/java/org/folio/oaipmh/service/impl/SetServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.impl.OkapiMockServer.OAI_TEST_TENANT;
 import static org.folio.rest.jooq.Tables.SET_LB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,6 +38,7 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.google.common.collect.ImmutableList;
@@ -49,6 +51,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.pgclient.PgException;
 
+@TestInstance(PER_CLASS)
 @ExtendWith(VertxExtension.class)
 class SetServiceImplTest extends AbstractSetTest {
 
@@ -60,17 +63,14 @@ class SetServiceImplTest extends AbstractSetTest {
   private static PostgresClientFactory postgresClientFactory;
   private SetService setService;
 
-  {
-    SetDao setDao = new SetDaoImpl(postgresClientFactory);
-    setService = new SetServiceImpl(setDao);
-  }
-
   @BeforeAll
-  static void setUpClass(Vertx vertx, VertxTestContext testContext) throws Exception {
+  void setUpClass(Vertx vertx, VertxTestContext testContext) throws Exception {
     PostgresClientFactory.setShouldResetPool(true);
     postgresClientFactory = new PostgresClientFactory(vertx);
     PostgresClient.getInstance(vertx)
       .startEmbeddedPostgres();
+    SetDao setDao = new SetDaoImpl(postgresClientFactory);
+    setService = new SetServiceImpl(setDao);
 
     TestUtil.prepareDatabase(vertx, testContext, OAI_TEST_TENANT, List.of(SET_LB));
     new OkapiMockServer(vertx, mockPort).start(testContext);
@@ -80,7 +80,7 @@ class SetServiceImplTest extends AbstractSetTest {
   }
 
   @AfterAll
-  static void tearDownClass(Vertx vertx, VertxTestContext testContext) {
+  void tearDownClass(Vertx vertx, VertxTestContext testContext) {
     PostgresClientFactory.closeAll();
     vertx.close(testContext.succeeding(res -> {
       PostgresClient.stopEmbeddedPostgres();

--- a/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
+++ b/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
@@ -74,7 +74,7 @@ class CleanUpJobTest extends AbstractInstancesTest {
     RestAssured.port = okapiPort;
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
-    PostgresClient client = PostgresClient.getInstance(vertx);
+    PostgresClient client = PostgresClient.getInstance(vertx, OAI_TEST_TENANT);
     client.startEmbeddedPostgres();
 
     JsonObject dpConfig = new JsonObject();

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -169,7 +169,7 @@ import net.jcip.annotations.NotThreadSafe;
 @NotThreadSafe
 @ExtendWith(VertxExtension.class)
 @TestInstance(PER_CLASS)
-public class OaiPmhImplTest {
+class OaiPmhImplTest {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -169,7 +169,7 @@ import net.jcip.annotations.NotThreadSafe;
 @NotThreadSafe
 @ExtendWith(VertxExtension.class)
 @TestInstance(PER_CLASS)
-class OaiPmhImplTest {
+public class OaiPmhImplTest {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -254,9 +254,16 @@ class OaiPmhImplTest {
   }
 
   @AfterAll
-  void cleanUpAfterAll() {
+  void cleanUpAfterAll(Vertx vertx, VertxTestContext testContext) {
     PostgresClientFactory.closeAll();
     PostgresClient.stopEmbeddedPostgres();
+    vertx.close(res -> {
+      if(res.succeeded()) {
+        testContext.completeNow();
+      } else {
+        testContext.failNow(res.cause());
+      }
+    });
   }
 
   @BeforeEach


### PR DESCRIPTION
### PURPOSE
Tests that are run after OaiPmhImplTest and uses the database cannot obtain normal connections cause some threads after OaiPmhImplTest still hand the connections from the pool associated with the test tenant oaiTest.

### PURPOSE
Reset the connection pool before each test that uses the database.