### PR TITLE
MODOAIPMH-294: make resumptionToken be reusable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 3.3.0 (Released) 2021-01-28
+
+This release includes the bug fixes and improvements regarding marc21_withholdings metadata prefix processing.
+
+* [MODOAIPMH-282](https://issues.folio.org/browse/MODOAIPMH-282) On 7M records first response to the initial requests with marc21_withholdings metadataPrefix takes more than 20 min
+* [MODOAIPMH-284](https://issues.folio.org/browse/MODOAIPMH-284) Return response immediately after the required number of instances will be loaded instead of waiting for completion of all instances loading.
+
+  [Full Changelog](https://github.com/folio-org/mod-data-export/compare/v3.2.7...v3.3.0)
+
 ## 3.2.7 (Released) 2021-01-13
 
 This release includes the bug fix for marc21_withholdings metadata prefix request.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-oai-pmh</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.1-SNAPSHOT</version>
 
   <name>OAI-PMH Repository Business Logic</name>
   <description>Business logic to support the Open Archives Initiative Protocol for Metadata Harvesting</description>
@@ -18,7 +18,7 @@
     <url>https://github.com/folio-org/mod-oai-pmh.git</url>
     <connection>scm:git:git://github.com/folio-org/mod-oai-pmh.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-oai-pmh.git</developerConnection>
-    <tag>v3.2.4</tag>
+    <tag>v3.3.0</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -9,6 +9,7 @@ public final class Constants {
   }
 
 
+
   /**
    * Strict ISO Date and Time with UTC offset.
    * Represents {@linkplain org.openarchives.oai._2.GranularityType#YYYY_MM_DD_THH_MM_SS_Z YYYY_MM_DD_THH_MM_SS_Z} granularity
@@ -55,6 +56,7 @@ public final class Constants {
   public static final String OFFSET_PARAM = "offset";
   public static final String TOTAL_RECORDS_PARAM = "totalRecords";
   public static final String NEXT_RECORD_ID_PARAM = "nextRecordId";
+  public static final String NEXT_INSTANCE_PK_VALUE = "nextInstancePkValue";
   public static final String REQUEST_ID_PARAM = "requestId";
   public static final String VERB_PARAM = "verb";
 

--- a/src/main/java/org/folio/oaipmh/Request.java
+++ b/src/main/java/org/folio/oaipmh/Request.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toMap;
 import static org.folio.oaipmh.Constants.FROM_PARAM;
 import static org.folio.oaipmh.Constants.METADATA_PREFIX_PARAM;
+import static org.folio.oaipmh.Constants.NEXT_INSTANCE_PK_VALUE;
 import static org.folio.oaipmh.Constants.NEXT_RECORD_ID_PARAM;
 import static org.folio.oaipmh.Constants.OFFSET_PARAM;
 import static org.folio.oaipmh.Constants.OKAPI_TENANT;
@@ -49,9 +50,10 @@ public class Request {
   private int totalRecords;
   /** The id of the first record in the next set of results used for partitioning. */
   private String nextRecordId;
-
    /** The id of the request. */
   private String requestId;
+  /** The PK id of the first record in the next set of results used for partitioning. */
+  private int nextInstancePkValue;
 
   /**
    * Builder used to build the request.
@@ -188,6 +190,10 @@ public class Request {
     return nextRecordId;
   }
 
+  public int getNextInstancePkValue() {
+    return nextInstancePkValue;
+  }
+
   public String getRequestId() {
     return requestId;
   }
@@ -202,6 +208,10 @@ public class Request {
 
   public String getOkapiUrl() {
     return okapiUrl;
+  }
+
+  public void setNextInstancePkValue(int nextInstancePkValue) {
+    this.nextInstancePkValue = nextInstancePkValue;
   }
 
   /**
@@ -242,6 +252,7 @@ public class Request {
       this.totalRecords = value == null ? 0 : Integer.parseInt(value);
       this.nextRecordId = params.get(NEXT_RECORD_ID_PARAM);
       this.requestId = params.get(REQUEST_ID_PARAM);
+      this.nextInstancePkValue = Integer.parseInt(params.get(NEXT_INSTANCE_PK_VALUE));
     } catch (Exception e) {
       return false;
     }

--- a/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
+++ b/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
@@ -52,4 +52,10 @@ public interface InstancesDao {
    * Retrieves instances by limit and request id.
    */
   Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
+
+  /**
+   * Retrieves instances which have PK id value >= id by limit and request id.
+   */
+  Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId);
+
 }

--- a/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
+++ b/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
@@ -201,6 +201,18 @@ public class InstancesDaoImpl implements InstancesDao {
     return getQueryExecutor(tenantId).transaction(queryExecutor -> queryExecutor
       .query(dslContext -> dslContext.selectFrom(INSTANCES)
         .where(INSTANCES.REQUEST_ID.eq(UUID.fromString(requestId)))
+        .orderBy(INSTANCES.ID)
+        .limit(limit))
+      .map(this::queryResultToInstancesList));
+  }
+
+  @Override
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId) {
+    return getQueryExecutor(tenantId).transaction(queryExecutor -> queryExecutor
+      .query(dslContext -> dslContext.selectFrom(INSTANCES)
+        .where(INSTANCES.REQUEST_ID.eq(UUID.fromString(requestId)))
+        .and(INSTANCES.ID.greaterOrEqual(id))
+        .orderBy(INSTANCES.ID)
         .limit(limit))
       .map(this::queryResultToInstancesList));
   }
@@ -214,6 +226,7 @@ public class InstancesDaoImpl implements InstancesDao {
         pojo.setInstanceId(row.getUUID(INSTANCES.INSTANCE_ID.getName()));
         pojo.setJson(row.getString(INSTANCES.JSON.getName()));
         pojo.setRequestId(row.getUUID(INSTANCES.REQUEST_ID.getName()));
+        pojo.setId(row.getInteger(INSTANCES.ID.getName()));
         return pojo;
       })
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/oaipmh/service/InstancesService.java
+++ b/src/main/java/org/folio/oaipmh/service/InstancesService.java
@@ -56,4 +56,9 @@ public interface InstancesService {
    */
   Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
 
+  /**
+   * Retrieves instances which have PK id value >= id by limit and request id.
+   */
+  Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId);
+
 }

--- a/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
+++ b/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
@@ -96,6 +96,11 @@ public class InstancesServiceImpl implements InstancesService {
     return instancesDao.getInstancesList(limit, requestId, tenantId);
   }
 
+  @Override
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId) {
+    return instancesDao.getInstancesList(limit, requestId, id, tenantId);
+  }
+
   @Autowired
   public InstancesDao setInstancesDao() {
     return instancesDao;

--- a/src/main/resources/liquibase/tenant/scripts/2020-07-16--10-00-create-instnace-ids-table.xml
+++ b/src/main/resources/liquibase/tenant/scripts/2020-07-16--10-00-create-instnace-ids-table.xml
@@ -18,4 +18,10 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="2021-02-24--12-00-add-autoIncrement-pk" author="Illia Daliek">
+    <addColumn tableName="instances">
+      <column name="id" type="integer" autoIncrement="true"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/liquibase/tenant/scripts/2020-11-19--18-00-create-request-metadata-table.xml
+++ b/src/main/resources/liquibase/tenant/scripts/2020-11-19--18-00-create-request-metadata-table.xml
@@ -54,4 +54,10 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="2021-02-23--13-00-add-index-to-instances-table-on-request_id-column" author="Illia Daliek">
+    <createIndex tableName="instances" indexName="request_id_idx" unique="false">
+      <column name="request_id"/>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/test/resources/inventory_view/instance_id_to_make_srs_fail_with_502.json
+++ b/src/test/resources/inventory_view/instance_id_to_make_srs_fail_with_502.json
@@ -1,0 +1,1 @@
+{  "instanceId": "927ee35f-700c-4fdd-a7e9-b560861d6900", "source": "FOLIO", "updatedDate": "2020-06-15T11:07:48.563Z",  "deleted": "false",  "suppressFromDiscovery": "false"}


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-294

### PURPOSE
It is required to make the resumption token reusable. The previous implementation didn't allow reuse of the res. token by the reason that processed instances were deleted and therefore they couldn't be reused anymore.

### APPROACH
1) Remove deleting of instances after they have been processed.
2) Requesting instances ids:
2.1 first batch = true 
select first instances by request_id and order by id.
if the number of instances returned > batchSize (which means that it not the last batch) we grab the id of the last instance and put it to resumption token.
2.2 first batch = false
we grab the id from the resumption token and make the same select query as before but with additional criteria where id >= id value from resumption token.

