### PR TITLE
MODOAIPMH-294: make resumptionToken be reusable

### DIFF
--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -9,6 +9,7 @@ public final class Constants {
   }
 
 
+
   /**
    * Strict ISO Date and Time with UTC offset.
    * Represents {@linkplain org.openarchives.oai._2.GranularityType#YYYY_MM_DD_THH_MM_SS_Z YYYY_MM_DD_THH_MM_SS_Z} granularity
@@ -55,6 +56,7 @@ public final class Constants {
   public static final String OFFSET_PARAM = "offset";
   public static final String TOTAL_RECORDS_PARAM = "totalRecords";
   public static final String NEXT_RECORD_ID_PARAM = "nextRecordId";
+  public static final String NEXT_INSTANCE_PK_VALUE = "nextInstancePkValue";
   public static final String REQUEST_ID_PARAM = "requestId";
   public static final String VERB_PARAM = "verb";
 

--- a/src/main/java/org/folio/oaipmh/Request.java
+++ b/src/main/java/org/folio/oaipmh/Request.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toMap;
 import static org.folio.oaipmh.Constants.FROM_PARAM;
 import static org.folio.oaipmh.Constants.METADATA_PREFIX_PARAM;
+import static org.folio.oaipmh.Constants.NEXT_INSTANCE_PK_VALUE;
 import static org.folio.oaipmh.Constants.NEXT_RECORD_ID_PARAM;
 import static org.folio.oaipmh.Constants.OFFSET_PARAM;
 import static org.folio.oaipmh.Constants.OKAPI_TENANT;
@@ -19,6 +20,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -49,9 +51,10 @@ public class Request {
   private int totalRecords;
   /** The id of the first record in the next set of results used for partitioning. */
   private String nextRecordId;
-
    /** The id of the request. */
   private String requestId;
+  /** The PK id of the first record in the next set of results used for partitioning. */
+  private int nextInstancePkValue;
 
   /**
    * Builder used to build the request.
@@ -188,6 +191,10 @@ public class Request {
     return nextRecordId;
   }
 
+  public int getNextInstancePkValue() {
+    return nextInstancePkValue;
+  }
+
   public String getRequestId() {
     return requestId;
   }
@@ -202,6 +209,10 @@ public class Request {
 
   public String getOkapiUrl() {
     return okapiUrl;
+  }
+
+  public void setNextInstancePkValue(int nextInstancePkValue) {
+    this.nextInstancePkValue = nextInstancePkValue;
   }
 
   /**
@@ -242,6 +253,9 @@ public class Request {
       this.totalRecords = value == null ? 0 : Integer.parseInt(value);
       this.nextRecordId = params.get(NEXT_RECORD_ID_PARAM);
       this.requestId = params.get(REQUEST_ID_PARAM);
+      if(Objects.nonNull(params.get(NEXT_INSTANCE_PK_VALUE))) {
+        this.nextInstancePkValue = Integer.parseInt(params.get(NEXT_INSTANCE_PK_VALUE));
+      }
     } catch (Exception e) {
       return false;
     }

--- a/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
+++ b/src/main/java/org/folio/oaipmh/dao/InstancesDao.java
@@ -52,4 +52,10 @@ public interface InstancesDao {
    * Retrieves instances by limit and request id.
    */
   Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
+
+  /**
+   * Retrieves instances which have PK id value >= id by limit and request id.
+   */
+  Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId);
+
 }

--- a/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
+++ b/src/main/java/org/folio/oaipmh/dao/impl/InstancesDaoImpl.java
@@ -206,6 +206,17 @@ public class InstancesDaoImpl implements InstancesDao {
       .map(this::queryResultToInstancesList));
   }
 
+  @Override
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId) {
+    return getQueryExecutor(tenantId).transaction(queryExecutor -> queryExecutor
+      .query(dslContext -> dslContext.selectFrom(INSTANCES)
+        .where(INSTANCES.REQUEST_ID.eq(UUID.fromString(requestId)))
+        .and(INSTANCES.ID.greaterOrEqual(id))
+        .orderBy(INSTANCES.ID)
+        .limit(limit))
+      .map(this::queryResultToInstancesList));
+  }
+
   private List<Instances> queryResultToInstancesList(QueryResult queryResult) {
     return queryResult.stream()
       .map(QueryResult::unwrap)
@@ -215,6 +226,7 @@ public class InstancesDaoImpl implements InstancesDao {
         pojo.setInstanceId(row.getUUID(INSTANCES.INSTANCE_ID.getName()));
         pojo.setJson(row.getString(INSTANCES.JSON.getName()));
         pojo.setRequestId(row.getUUID(INSTANCES.REQUEST_ID.getName()));
+        pojo.setId(row.getInteger(INSTANCES.ID.getName()));
         return pojo;
       })
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/oaipmh/service/InstancesService.java
+++ b/src/main/java/org/folio/oaipmh/service/InstancesService.java
@@ -56,4 +56,9 @@ public interface InstancesService {
    */
   Future<List<Instances>> getInstancesList(int limit, String requestId, String tenantId);
 
+  /**
+   * Retrieves instances which have PK id value >= id by limit and request id.
+   */
+  Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId);
+
 }

--- a/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
+++ b/src/main/java/org/folio/oaipmh/service/impl/InstancesServiceImpl.java
@@ -96,6 +96,11 @@ public class InstancesServiceImpl implements InstancesService {
     return instancesDao.getInstancesList(limit, requestId, tenantId);
   }
 
+  @Override
+  public Future<List<Instances>> getInstancesList(int limit, String requestId, int id, String tenantId) {
+    return instancesDao.getInstancesList(limit, requestId, id, tenantId);
+  }
+
   @Autowired
   public InstancesDao setInstancesDao() {
     return instancesDao;


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-294

### PURPOSE
It is required to make the resumption token reusable. The previous implementation didn't allow reuse of the res. token by the reason that processed instances were deleted and therefore they couldn't be reused anymore.

### APPROACH
Remove deleting of instances after they have been processed.
Requesting instances ids:
2.1 first batch = true
select first instances by request_id and order by id.
if the number of instances returned > batchSize (which means that it not the last batch) we grab the id of the last instance and put it to resumption token.
2.2 first batch = false
we grab the id from the resumption token and make the same select query as before but with additional criteria where id >= id value from resumption token.