### PR TITLE
MODOAIPMH-300: Not all instances ids are saved for initial harvest

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ OAI-PMH | `repository.maxRecordsPerResponse` | `100` | The maximum number of rec
 OAI-PMH | `jaxb.marshaller.enableValidation` | `false` | Boolean value which defines if the response content should be validated against xsd schemas.
 OAI-PMH | `jaxb.marshaller.formattedOutput` | `false` | Boolean value which is used to specify whether or not the marshalled XML data is formatted with linefeeds and indentation.
 OAI-PMH | `repository.errorsProcessing` | `500` | Defines in which way OAI-PMH level errors are going to be processed. `200` -  OAI-PMH level error is associated with HTTP status 200. `500` - OAI-PMH level error may be associated with HTTP error status (4xx or 5xx). 
-OAI-PMH | `repository.enableOaiService` | `true` | Defines whether an OAI-PMH module is accessible in the repository. If `false`, then all other OAI-PMH settings are disabled and repository responds with 503.
+OAI-PMH | `repository.srsHttpRequestRetryAttempts` | `50` | Property is used in marc21_withholdings metadata prefix handler. If SRS returns an incorrect response then the same request will be sent again up to 50 times until the expected response will not be received or all 50 attempts will fail which leads to error response.
+OAI-PMH | `repository.srsClientIdleTimeoutSec` | `20` | The idle timeout for requests to SRS.
 
 ### Configuration priority resolving
 TenantApi 'POST' implementation is responsible for getting configurations for a module from mod-configuration and adjusting them to system properties when posting module for tenant. Since there 3 places of configurations (mod-configuration, JVM, default form resources), there are ways of resolving configuration inconsistencies when TenantAPI executes. <br/>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
+        <version>3.9.4-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
+        <version>3.9.4-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
@@ -119,7 +119,7 @@
     <!-- Plugin versions -->
     <aspectj.version>1.9.6</aspectj.version>
     <raml-module-builder.version>31.1.5</raml-module-builder.version>
-    <vertx.version>3.9.4</vertx.version>
+    <vertx.version>3.9.6</vertx.version>
     <vertx-completable-future.version>0.1.2</vertx-completable-future.version>
     <apache-httpclient.version>4.5.11</apache-httpclient.version>
     <apache-commons-lang3.version>3.9</apache-commons-lang3.version>

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -23,7 +23,7 @@ public final class Constants {
 
   public static final String REPOSITORY_BASE_URL = "repository.baseURL";
   public static final String REPOSITORY_MAX_RECORDS_PER_RESPONSE = "repository.maxRecordsPerResponse";
-  public static final String REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS = "repository.httpRequestRetryAttempts";
+  public static final String REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS = "repository.srsHttpRequestRetryAttempts";
   public static final String REPOSITORY_NAME = "repository.name";
   public static final String REPOSITORY_ADMIN_EMAILS = "repository.adminEmails";
   public static final String REPOSITORY_TIME_GRANULARITY = "repository.timeGranularity";

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -8,8 +8,6 @@ public final class Constants {
     throw new IllegalStateException("This class holds constants only");
   }
 
-
-
   /**
    * Strict ISO Date and Time with UTC offset.
    * Represents {@linkplain org.openarchives.oai._2.GranularityType#YYYY_MM_DD_THH_MM_SS_Z YYYY_MM_DD_THH_MM_SS_Z} granularity
@@ -25,6 +23,7 @@ public final class Constants {
 
   public static final String REPOSITORY_BASE_URL = "repository.baseURL";
   public static final String REPOSITORY_MAX_RECORDS_PER_RESPONSE = "repository.maxRecordsPerResponse";
+  public static final String REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS = "repository.httpRequestRetryAttempts";
   public static final String REPOSITORY_NAME = "repository.name";
   public static final String REPOSITORY_ADMIN_EMAILS = "repository.adminEmails";
   public static final String REPOSITORY_TIME_GRANULARITY = "repository.timeGranularity";

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -8,6 +8,7 @@ public final class Constants {
     throw new IllegalStateException("This class holds constants only");
   }
 
+
   /**
    * Strict ISO Date and Time with UTC offset.
    * Represents {@linkplain org.openarchives.oai._2.GranularityType#YYYY_MM_DD_THH_MM_SS_Z YYYY_MM_DD_THH_MM_SS_Z} granularity
@@ -21,9 +22,12 @@ public final class Constants {
   public static final String OKAPI_TENANT = "X-Okapi-Tenant";
   public static final String OKAPI_TOKEN = "X-Okapi-Token";
 
+  public static final String JAXB_MARSHALLER_FORMATTED_OUTPUT = "jaxb.marshaller.formattedOutput";
+  public static final String JAXB_MARSHALLER_ENABLE_VALIDATION = "jaxb.marshaller.enableValidation";
   public static final String REPOSITORY_BASE_URL = "repository.baseURL";
   public static final String REPOSITORY_MAX_RECORDS_PER_RESPONSE = "repository.maxRecordsPerResponse";
   public static final String REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS = "repository.srsHttpRequestRetryAttempts";
+  public static final String REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC = "repository.srsClientIdleTimeoutSec";
   public static final String REPOSITORY_NAME = "repository.name";
   public static final String REPOSITORY_ADMIN_EMAILS = "repository.adminEmails";
   public static final String REPOSITORY_TIME_GRANULARITY = "repository.timeGranularity";

--- a/src/main/java/org/folio/oaipmh/ResponseConverter.java
+++ b/src/main/java/org/folio/oaipmh/ResponseConverter.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
+import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_ENABLE_VALIDATION;
+import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_FORMATTED_OUTPUT;
 
 @SuppressWarnings("squid:S1191") //The com.sun.xml.bind.marshaller.NamespacePrefixMapper is part of jaxb logic
 public class ResponseConverter {
@@ -68,7 +70,7 @@ public class ResponseConverter {
   private ResponseConverter() throws JAXBException, SAXException {
     jaxbContext = JAXBContext.newInstance(OAIPMH.class, RecordType.class, Dc.class, OaiIdentifier.class, ObjectFactory.class);
     // Specifying OAI-PMH schema to validate response if the validation is enabled. Enabled by default if no config specified
-    if (Boolean.parseBoolean(System.getProperty("jaxb.marshaller.enableValidation", Boolean.TRUE.toString()))) {
+    if (Boolean.parseBoolean(System.getProperty(JAXB_MARSHALLER_ENABLE_VALIDATION, Boolean.TRUE.toString()))) {
       ClassLoader classLoader = this.getClass().getClassLoader();
       StreamSource[] streamSources = {
         new StreamSource(classLoader.getResourceAsStream(RESPONSE_SCHEMA)),
@@ -105,7 +107,7 @@ public class ResponseConverter {
       jaxbMarshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
         "http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd");
       // Specifying if output should be formatted
-      jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.parseBoolean(System.getProperty("jaxb.marshaller.formattedOutput")));
+      jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.parseBoolean(System.getProperty(JAXB_MARSHALLER_FORMATTED_OUTPUT)));
       // needed to replace the namespace prefixes with a more readable format.
       jaxbMarshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", namespacePrefixMapper);
       jaxbMarshaller.marshal(response, writer);

--- a/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
+++ b/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
@@ -67,7 +67,6 @@ public class SourceStorageSourceRecordsClient {
       buffer.appendString(ClientHelpers.pojo2json(List));
     }
 
-    logger.info("SRS CLIENT: step 1");
 
     HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + "/source-storage/source-records" + queryParams.toString());
     request.handler(responseHandler);
@@ -91,7 +90,6 @@ public class SourceStorageSourceRecordsClient {
     request.setChunked(true);
     request.write(buffer);
     request.end();
-    logger.info("SRS CLIENT: step 2");
   }
 
   public void close() {

--- a/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
+++ b/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
@@ -41,14 +41,14 @@ public class SourceStorageSourceRecordsClient {
   }
 
   public SourceStorageSourceRecordsClient(String okapiUrl, String tenantId, String token) {
-    this(okapiUrl, tenantId, token, true, 2000, 5000);
+    this(okapiUrl, tenantId, token, true, 2000, 20);
   }
 
   public SourceStorageSourceRecordsClient(SourceStorageSourceRecordsClient client) {
-    this(client.okapiUrl, client.tenantId, client.token, true, 2000, 5000);
+    this(client.okapiUrl, client.tenantId, client.token, true, 2000, 20);
   }
 
-  public void postSourceStorageSourceRecords(String idType, Boolean deleted, List List, Handler<HttpClientResponse> responseHandler) throws UnsupportedEncodingException, Exception {
+  public void postSourceStorageSourceRecords(String idType, Boolean deleted, List List, Handler<HttpClientResponse> responseHandler, Handler<Throwable> exceptionHandler ) throws UnsupportedEncodingException, Exception {
     StringBuilder queryParams = new StringBuilder("?");
     if (idType != null) {
       queryParams.append("idType=");
@@ -71,6 +71,11 @@ public class SourceStorageSourceRecordsClient {
 
     HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + "/source-storage/source-records" + queryParams.toString());
     request.handler(responseHandler);
+    request.exceptionHandler(e-> {
+      logger.error("SRS response error 1234: " + e.getMessage(), e);
+      exceptionHandler.handle(e);
+    });
+    request.setTimeout(10000);
     request.putHeader("Content-type", "application/json");
     request.putHeader("Accept", "application/json,text/plain");
     if (this.tenantId != null) {

--- a/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
+++ b/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
@@ -74,10 +74,7 @@ public class SourceStorageSourceRecordsClient {
 
     HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + GLOBAL_PATH + queryParams.toString());
     request.handler(responseHandler);
-    request.exceptionHandler(e-> {
-      logger.error("Error has been occurred while requesting SRS: " + e.getMessage(), e);
-      exceptionHandler.handle(e);
-    });
+    request.exceptionHandler(exceptionHandler);
     request.setTimeout(DEFAULT_SRS_TIMEOUT);
     request.putHeader("Content-type", "application/json");
     request.putHeader("Accept", "application/json,text/plain");

--- a/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
+++ b/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
@@ -1,5 +1,6 @@
 package org.folio.oaipmh.client;
 
+import static java.lang.String.format;
 import static org.folio.oaipmh.Constants.REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC;
 
 import java.io.UnsupportedEncodingException;
@@ -27,10 +28,11 @@ public class SourceStorageSourceRecordsClient {
 
   private static final Logger logger = LoggerFactory.getLogger(SourceStorageSourceRecordsClient.class);
 
-  private static final String GLOBAL_PATH = "/source-storage/source-records";
+  private static final String SOURCE_RECORDS_PATH = "/source-storage/source-records";
   private static final int DEFAULT_SRS_TIMEOUT = 10000;
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 2000;
   private static final int DEFAULT_IDLE_TIMEOUT_SEC = 20;
+  private static final String GET_IDLE_TIMEOUT_ERROR_MESSAGE = "Error occurred during resolving the idle timeout setting value. Setup client with default idle timeout " + DEFAULT_IDLE_TIMEOUT_SEC + " seconds";
 
   protected String tenantId;
   protected String token;
@@ -77,7 +79,7 @@ public class SourceStorageSourceRecordsClient {
       buffer.appendString(ClientHelpers.pojo2json(List));
     }
 
-    HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + GLOBAL_PATH + queryParams.toString());
+    HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + SOURCE_RECORDS_PATH + queryParams.toString());
     request.handler(responseHandler);
     request.exceptionHandler(exceptionHandler);
     request.setTimeout(DEFAULT_SRS_TIMEOUT);
@@ -109,8 +111,11 @@ public class SourceStorageSourceRecordsClient {
       .map(config -> config.getString(REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC, defaultValue))
       .orElse(defaultValue);
     try {
-      return Integer.parseInt(val);
+      int configValue = Integer.parseInt(val);
+      logger.debug(format("Setup client with idle timeout '%s' seconds", configValue));
+      return configValue;
     } catch (Exception e) {
+      logger.error(GET_IDLE_TIMEOUT_ERROR_MESSAGE, e);
       return DEFAULT_IDLE_TIMEOUT_SEC;
     }
   }

--- a/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
+++ b/src/main/java/org/folio/oaipmh/client/SourceStorageSourceRecordsClient.java
@@ -2,37 +2,31 @@ package org.folio.oaipmh.client;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.List;
 
 import org.folio.rest.tools.ClientHelpers;
 import org.folio.rest.tools.utils.VertxUtils;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
-import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 //TODO Should be replaced with the SourceStorageSourceRecordsClient from mod-source-record-storage-client
 // when it's upgraded to RMD version 32 and Vert.x version 4
 public class SourceStorageSourceRecordsClient {
   private static final String GLOBAL_PATH = "/source-storage/source-records";
-  private String tenantId;
-  private String token;
-  private String okapiUrl;
+  protected String tenantId;
+  protected String token;
+  protected String okapiUrl;
   private HttpClientOptions options;
   private HttpClient httpClient;
+
+  private static final Logger logger = LoggerFactory.getLogger(SourceStorageSourceRecordsClient.class);
 
   public SourceStorageSourceRecordsClient(String okapiUrl, String tenantId, String token, boolean keepAlive, int connTO, int idleTO) {
     this.tenantId = tenantId;
@@ -48,6 +42,10 @@ public class SourceStorageSourceRecordsClient {
 
   public SourceStorageSourceRecordsClient(String okapiUrl, String tenantId, String token) {
     this(okapiUrl, tenantId, token, true, 2000, 5000);
+  }
+
+  public SourceStorageSourceRecordsClient(SourceStorageSourceRecordsClient client) {
+    this(client.okapiUrl, client.tenantId, client.token, true, 2000, 5000);
   }
 
   public void postSourceStorageSourceRecords(String idType, Boolean deleted, List List, Handler<HttpClientResponse> responseHandler) throws UnsupportedEncodingException, Exception {
@@ -69,6 +67,8 @@ public class SourceStorageSourceRecordsClient {
       buffer.appendString(ClientHelpers.pojo2json(List));
     }
 
+    logger.info("SRS CLIENT: step 1");
+
     HttpClientRequest request = this.httpClient.postAbs(this.okapiUrl + "/source-storage/source-records" + queryParams.toString());
     request.handler(responseHandler);
     request.putHeader("Content-type", "application/json");
@@ -86,6 +86,7 @@ public class SourceStorageSourceRecordsClient {
     request.setChunked(true);
     request.write(buffer);
     request.end();
+    logger.info("SRS CLIENT: step 2");
   }
 
   public void close() {

--- a/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
@@ -28,7 +28,7 @@ public class BatchStreamWrapper implements WriteStream<JsonEvent> {
   private volatile boolean streamEnded = false;
 
   private volatile boolean endedWithError = false;
-  private AtomicReference<Throwable> cause;
+  private AtomicReference<Throwable> cause = new AtomicReference<>();
 
   private final List<JsonEvent> dataList = new CopyOnWriteArrayList<>();
 

--- a/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
@@ -3,10 +3,10 @@ package org.folio.oaipmh.helpers.streaming;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
-import com.sun.jdi.PrimitiveValue;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -28,7 +28,7 @@ public class BatchStreamWrapper implements WriteStream<JsonEvent> {
   private volatile boolean streamEnded = false;
 
   private volatile boolean endedWithError = false;
-  private volatile Throwable cause;
+  private AtomicReference<Throwable> cause;
 
   private final List<JsonEvent> dataList = new CopyOnWriteArrayList<>();
 
@@ -144,11 +144,11 @@ public class BatchStreamWrapper implements WriteStream<JsonEvent> {
   }
 
   public Throwable getCause() {
-    return cause;
+    return cause.get();
   }
 
   public synchronized void endWithError(Throwable cause) {
-    this.cause = cause;
+    this.cause.set(cause);
     this.endedWithError = true;
     end();
   }

--- a/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/streaming/BatchStreamWrapper.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
+import com.sun.jdi.PrimitiveValue;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -25,6 +26,9 @@ public class BatchStreamWrapper implements WriteStream<JsonEvent> {
   private volatile int batchSize;
 
   private volatile boolean streamEnded = false;
+
+  private volatile boolean endedWithError = false;
+  private volatile Throwable cause;
 
   private final List<JsonEvent> dataList = new CopyOnWriteArrayList<>();
 
@@ -133,6 +137,20 @@ public class BatchStreamWrapper implements WriteStream<JsonEvent> {
 
   public boolean isStreamEnded() {
     return streamEnded;
+  }
+
+  public boolean isEndedWithError() {
+    return endedWithError;
+  }
+
+  public Throwable getCause() {
+    return cause;
+  }
+
+  public synchronized void endWithError(Throwable cause) {
+    this.cause = cause;
+    this.endedWithError = true;
+    end();
   }
 
   public Long getReturnedCount() {

--- a/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
@@ -4,6 +4,20 @@ import java.util.HashMap;
 import java.util.Map;
 import org.folio.oaipmh.Constants;
 
+import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_ENABLE_VALIDATION;
+import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_FORMATTED_OUTPUT;
+import static org.folio.oaipmh.Constants.REPOSITORY_ADMIN_EMAILS;
+import static org.folio.oaipmh.Constants.REPOSITORY_BASE_URL;
+import static org.folio.oaipmh.Constants.REPOSITORY_DELETED_RECORDS;
+import static org.folio.oaipmh.Constants.REPOSITORY_ENABLE_OAI_SERVICE;
+import static org.folio.oaipmh.Constants.REPOSITORY_ERRORS_PROCESSING;
+import static org.folio.oaipmh.Constants.REPOSITORY_MAX_RECORDS_PER_RESPONSE;
+import static org.folio.oaipmh.Constants.REPOSITORY_NAME;
+import static org.folio.oaipmh.Constants.REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC;
+import static org.folio.oaipmh.Constants.REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS;
+import static org.folio.oaipmh.Constants.REPOSITORY_SUPPRESSED_RECORDS_PROCESSING;
+import static org.folio.oaipmh.Constants.REPOSITORY_TIME_GRANULARITY;
+
 /**
  * Mapper is used for mapping names of frontend property names to server names.
  */
@@ -13,18 +27,19 @@ public class PropertyNameMapper {
   private static Map<String, String> backendToFrontendMapper = new HashMap<>();
 
   static {
-    frontendToBackendMapper.put("deletedRecordsSupport", "repository.deletedRecords");
-    frontendToBackendMapper.put("suppressedRecordsProcessing", "repository.suppressedRecordsProcessing");
-    frontendToBackendMapper.put("errorsProcessing", "repository.errorsProcessing");
-    frontendToBackendMapper.put("enableOaiService", "repository.enableOaiService");
-    frontendToBackendMapper.put("repositoryName", "repository.name");
-    frontendToBackendMapper.put("baseUrl", "repository.baseURL");
-    frontendToBackendMapper.put("administratorEmail", "repository.adminEmails");
-    frontendToBackendMapper.put("timeGranularity", "repository.timeGranularity");
-    frontendToBackendMapper.put("maxRecordsPerResponse", "repository.maxRecordsPerResponse");
-    frontendToBackendMapper.put("enableValidation", "jaxb.marshaller.enableValidation");
-    frontendToBackendMapper.put("formattedOutput", "jaxb.marshaller.formattedOutput");
-    frontendToBackendMapper.put("srsHttpRequestRetryAttempts", "repository.srsHttpRequestRetryAttempts");
+    frontendToBackendMapper.put("deletedRecordsSupport", REPOSITORY_DELETED_RECORDS);
+    frontendToBackendMapper.put("suppressedRecordsProcessing", REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
+    frontendToBackendMapper.put("errorsProcessing", REPOSITORY_ERRORS_PROCESSING);
+    frontendToBackendMapper.put("enableOaiService", REPOSITORY_ENABLE_OAI_SERVICE);
+    frontendToBackendMapper.put("repositoryName", REPOSITORY_NAME);
+    frontendToBackendMapper.put("baseUrl", REPOSITORY_BASE_URL);
+    frontendToBackendMapper.put("administratorEmail", REPOSITORY_ADMIN_EMAILS);
+    frontendToBackendMapper.put("timeGranularity", REPOSITORY_TIME_GRANULARITY);
+    frontendToBackendMapper.put("maxRecordsPerResponse", REPOSITORY_MAX_RECORDS_PER_RESPONSE);
+    frontendToBackendMapper.put("enableValidation", JAXB_MARSHALLER_ENABLE_VALIDATION);
+    frontendToBackendMapper.put("formattedOutput", JAXB_MARSHALLER_FORMATTED_OUTPUT);
+    frontendToBackendMapper.put("srsHttpRequestRetryAttempts", REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS);
+    frontendToBackendMapper.put("srsClientIdleTimeoutSec", REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC);
     frontendToBackendMapper.forEach((key, value) -> backendToFrontendMapper.put(value, key));
   }
 

--- a/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
@@ -24,7 +24,7 @@ public class PropertyNameMapper {
     frontendToBackendMapper.put("maxRecordsPerResponse", "repository.maxRecordsPerResponse");
     frontendToBackendMapper.put("enableValidation", "jaxb.marshaller.enableValidation");
     frontendToBackendMapper.put("formattedOutput", "jaxb.marshaller.formattedOutput");
-    frontendToBackendMapper.put("httpRequestRetryAttempts", "repository.srsHttpRequestRetryAttempts");
+    frontendToBackendMapper.put("srsHttpRequestRetryAttempts", "repository.srsHttpRequestRetryAttempts");
     frontendToBackendMapper.forEach((key, value) -> backendToFrontendMapper.put(value, key));
   }
 

--- a/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
@@ -2,6 +2,7 @@ package org.folio.oaipmh.mappers;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.folio.oaipmh.Constants;
 
 /**
  * Mapper is used for mapping names of frontend property names to server names.
@@ -23,6 +24,7 @@ public class PropertyNameMapper {
     frontendToBackendMapper.put("maxRecordsPerResponse", "repository.maxRecordsPerResponse");
     frontendToBackendMapper.put("enableValidation", "jaxb.marshaller.enableValidation");
     frontendToBackendMapper.put("formattedOutput", "jaxb.marshaller.formattedOutput");
+    frontendToBackendMapper.put("httpRequestRetryAttempts", "repository.httpRequestRetryAttempts");
     frontendToBackendMapper.forEach((key, value) -> backendToFrontendMapper.put(value, key));
   }
 

--- a/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
@@ -24,7 +24,7 @@ public class PropertyNameMapper {
     frontendToBackendMapper.put("maxRecordsPerResponse", "repository.maxRecordsPerResponse");
     frontendToBackendMapper.put("enableValidation", "jaxb.marshaller.enableValidation");
     frontendToBackendMapper.put("formattedOutput", "jaxb.marshaller.formattedOutput");
-    frontendToBackendMapper.put("httpRequestRetryAttempts", "repository.httpRequestRetryAttempts");
+    frontendToBackendMapper.put("httpRequestRetryAttempts", "repository.srsHttpRequestRetryAttempts");
     frontendToBackendMapper.forEach((key, value) -> backendToFrontendMapper.put(value, key));
   }
 

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -145,6 +145,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
    */
   @Override
   public Future<Response> handle(Request request, Context vertxContext) {
+    logger.info("Step 1");
     Promise<Response> promise = Promise.promise();
     try {
       String resumptionToken = request.getResumptionToken();
@@ -167,7 +168,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
         requestId = request.getRequestId();
         updateRequestMetadataFuture = instancesService.updateRequestUpdatedDate(requestId, lastUpdateDate, request.getTenant());
       }
-
+      logger.info("Step 2");
       updateRequestMetadataFuture.onSuccess(res -> {
         boolean isFirstBatch = resumptionToken == null;
         processBatch(request, vertxContext, promise, requestId, isFirstBatch);
@@ -188,6 +189,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
   private void processBatch(Request request, Context context, Promise<Response> oaiPmhResponsePromise, String requestId, boolean firstBatch) {
     try {
+      logger.info("Step 3");
       boolean deletedRecordSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
       int batchSize = Integer.parseInt(
         RepositoryConfigurationUtil.getProperty(request.getTenant(),
@@ -199,6 +201,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
           oaiPmhResponsePromise.fail(fut.cause());
           return;
         }
+
         List<JsonObject> instances = fut.result();
         logger.info("Processing instances: " + instances.size());
         if (CollectionUtils.isEmpty(instances) && !firstBatch) {
@@ -207,14 +210,17 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
           return;
         }
 
+        logger.info("Step 16");
         if (!firstBatch && (CollectionUtils.isNotEmpty(instances) && !instances.get(0).getString(INSTANCE_ID_FIELD_NAME).equals(request.getNextRecordId()))) {
           handleException(oaiPmhResponsePromise, new IllegalArgumentException(
             "Stale resumption token"));
           return;
         }
 
+        logger.info("Step 17");
         if (CollectionUtils.isEmpty(instances)) {
-          logger.warn("Got empty instances");
+          logger.info("Step 17.1 empty instances");
+          logger.debug("Got empty instances");
           buildRecordsResponse(request, requestId, instances, new HashMap<>(),
             firstBatch, null, deletedRecordSupport)
             .onSuccess(oaiPmhResponsePromise::complete)
@@ -222,11 +228,13 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
           return;
         }
 
+        logger.info("Step 18");
         String nextInstanceId = instances.size() < batchSize ? null : instances.get(batchSize).getString(INSTANCE_ID_FIELD_NAME);
         List<JsonObject> instancesWithoutLast = nextInstanceId != null ? instances.subList(0, batchSize) : instances;
         final SourceStorageSourceRecordsClient srsClient = new SourceStorageSourceRecordsClient(request.getOkapiUrl(),
           request.getTenant(), request.getOkapiToken());
 
+        logger.info("Step 19");
         requestSRSByIdentifiers(srsClient, context.owner(), instancesWithoutLast, deletedRecordSupport)
           .onSuccess(res -> buildRecordsResponse(request, requestId, instancesWithoutLast, res,
           firstBatch, nextInstanceId, deletedRecordSupport).onSuccess(oaiPmhResponsePromise::complete)
@@ -355,20 +363,22 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
   private Promise<List<JsonObject>> getNextInstances(Request request, int batchSize, Context context, String requestId, boolean firstBatch) {
     Promise<List<JsonObject>> promise = Promise.promise();
-
+    logger.info("Step 4");
     final Promise<List<Instances>> listPromise = Promise.promise();
     AtomicInteger retryCount = new AtomicInteger();
-    context.owner().setPeriodic(POLLING_TIME_INTERVAL, timer -> getNextBatch(requestId, request, firstBatch, batchSize, listPromise, context, timer, retryCount));
-
+    getNextBatch(requestId, request, firstBatch, batchSize, listPromise, context, retryCount);
     listPromise.future()
       .compose(instances -> {
+        logger.info("Step 7");
         if (CollectionUtils.isNotEmpty(instances)) {
           List<JsonObject> jsonInstances = instances.stream()
             .map(Instances::getJson)
             .map(JsonObject::new)
             .collect(Collectors.toList());
+          logger.info("Step 8");
           if (instances.size() > batchSize) {
             request.setNextInstancePkValue(instances.get(batchSize).getId());
+            logger.info("Step 9");
           }
           return enrichInstances(jsonInstances, request, context);
         }
@@ -384,46 +394,53 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
   }
 
   private void getNextBatch(String requestId, Request request, boolean firstBatch, int batchSize, Promise<List<Instances>> listPromise, Context context,
-                            Long timerId, AtomicInteger retryCount) {
+                            AtomicInteger retryCount) {
     if (retryCount.incrementAndGet() > MAX_POLLING_ATTEMPTS) {
-      context.owner().cancelTimer(timerId);
       listPromise.fail(new IllegalStateException("The instance list is empty after " + retryCount.get() + " attempts. Stop polling and return fail response"));
       return;
     }
+    logger.info("Step 5, POLLING ATTEMPTS: " + MAX_POLLING_ATTEMPTS + ", RETRY COUNT: " + retryCount.get());
     instancesService.getRequestMetadataByRequestId(requestId, request.getTenant())
-      .compose(requestMetadata -> Future.succeededFuture(requestMetadata.getStreamEnded()))
+      .compose(requestMetadata -> {
+        logger.info("Step 5.1, got request metadata, stream ended: " + requestMetadata.getStreamEnded());
+        return Future.succeededFuture(requestMetadata.getStreamEnded());
+      })
       .compose(streamEnded ->
       {
         if (firstBatch) {
+          logger.info("Step 6: first batch");
           return instancesService.getInstancesList(batchSize + 1, requestId, request.getTenant())
-            .onComplete(handleInstancesDbResponse(listPromise, timerId, streamEnded, batchSize, context));
+            .onComplete(handleInstancesDbResponse(listPromise, streamEnded, batchSize, timer -> getNextBatch(requestId, request, firstBatch, batchSize, listPromise, context, retryCount)));
         }
+        logger.info("Step 6: resumption token request");
         int autoIncrementedId = request.getNextInstancePkValue();
         return instancesService.getInstancesList(batchSize + 1, requestId, autoIncrementedId, request.getTenant())
-          .onComplete(handleInstancesDbResponse(listPromise, timerId, streamEnded, batchSize, context));
+          .onComplete(handleInstancesDbResponse(listPromise, streamEnded, batchSize, timer -> getNextBatch(requestId, request, firstBatch, batchSize, listPromise, context, retryCount)));
       });
   }
 
-  private Handler<AsyncResult<List<Instances>>> handleInstancesDbResponse(Promise<List<Instances>> listPromise, Long timerId, boolean streamEnded,
-                                                                          int batchSize, Context context) {
+  private Handler<AsyncResult<List<Instances>>> handleInstancesDbResponse(Promise<List<Instances>> listPromise, boolean streamEnded, int batchSize, Handler<Long> handler) {
     return result -> {
       if (result.succeeded()) {
         if (!listPromise.future().isComplete() && (result.result().size() == batchSize + 1 || streamEnded)) {
-          context.owner().cancelTimer(timerId);
           listPromise.complete(result.result());
+        } else {
+          vertx.setTimer(POLLING_TIME_INTERVAL, handler);
         }
       } else {
         logger.error(result.cause());
+        vertx.setTimer(POLLING_TIME_INTERVAL, handler);
       }
     };
   }
 
   private Future<List<JsonObject>> enrichInstances(List<JsonObject> result, Request request, Context context) {
+    logger.info("Step 10");
     Map<String, JsonObject> instances = result.stream()
       .collect(LinkedHashMap::new, (map, instance) -> map.put(instance.getString(INSTANCE_ID_FIELD_NAME), instance), Map::putAll);
     Promise<List<JsonObject>> completePromise = Promise.promise();
     HttpClient httpClient = context.owner().createHttpClient();
-
+    logger.info("Step 11");
     HttpClientRequest enrichInventoryClientRequest = createEnrichInventoryClientRequest(httpClient, request);
     BatchStreamWrapper enrichedInstancesStream = getBatchHttpStream(httpClient, completePromise, enrichInventoryClientRequest, context);
     JsonObject entries = new JsonObject();
@@ -441,9 +458,12 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
       return completePromise.future();
     }
 
+    logger.info("Step 12");
+
     enrichedInstancesStream.setCapacityChecker(() -> queue.get().size() > 20);
 
     enrichedInstancesStream.handleBatch(batch -> {
+      logger.info("Step 13");
       try {
         for (JsonEvent jsonEvent : batch) {
           JsonObject value = jsonEvent.objectValue();
@@ -462,9 +482,11 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
         }
 
         if (enrichedInstancesStream.isTheLastBatch() && !completePromise.future().isComplete()) {
+          logger.info("Step 14");
           completePromise.complete(new ArrayList<>(instances.values()));
         }
       } catch (Exception e) {
+        logger.info("Step 15");
         completePromise.fail(e);
       }
     });
@@ -489,8 +511,8 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
     Promise<Response> promise = Promise.promise();
     try {
+      logger.info("Step 24");
       List<RecordType> records = buildRecordsList(request, batch, srsResponse, deletedRecordSupport);
-
       logger.info("Build records response, instances = {0}, instances with srs records = {1}", batch.size(), records.size());
       ResponseHelper responseHelper = getResponseHelper();
       OAIPMH oaipmh = responseHelper.buildBaseOaipmhResponse(request);
@@ -525,6 +547,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     final boolean suppressedRecordsProcessing = getBooleanProperty(request.getOkapiHeaders(),
       REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
+    logger.info("Step 25");
     List<RecordType> records = new ArrayList<>();
     batch.stream()
       .filter(instance -> {
@@ -559,6 +582,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
         records.add(record);
       }
     });
+    logger.info("Step 26");
     return records;
   }
 
@@ -703,65 +727,74 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     return promise.future();
   }
 
-  private void doPostRequestToSrs(SourceStorageSourceRecordsClient srsClient, Vertx vertx, boolean deletedRecordSupport, List<String> listOfIds, AtomicInteger attemptsCount, Promise<Map<String, JsonObject>> promise) {
+  private void doPostRequestToSrs(SourceStorageSourceRecordsClient srsClient, Vertx vertx, boolean deletedRecordSupport,
+      List<String> listOfIds, AtomicInteger attemptsCount, Promise<Map<String, JsonObject>> promise) {
     try {
-      srsClient.postSourceStorageSourceRecords("INSTANCE", deletedRecordSupport, listOfIds, srsResponse -> {
-        int statusCode = srsResponse.statusCode();
-        String statusMessage = srsResponse.statusMessage();
-        if (statusCode != 200) {
-          if(statusCode >= 500) {
-            String warnMessage = "Got error response form SRS, status code: " + statusCode + ", status message: " + statusMessage;
-            logger.warn(warnMessage);
-            if (attemptsCount.get() <= 0) {
-              String errorMessage = "SRS didn't respond with expected status code after " + REQUEST_ATTEMPTS + " attempts. Canceling further request processing.";
+      logger.info("Step 20");
+      srsClient.postSourceStorageSourceRecords("INSTANCE", deletedRecordSupport, listOfIds,
+          srsResponse -> srsResponse.bodyHandler(buffer -> {
+            logger.info("Step 20.1 srs call handler, status code: " + srsResponse.statusCode());
+            int statusCode = srsResponse.statusCode();
+            String statusMessage = srsResponse.statusMessage();
+
+            if (statusCode >= 400) {
+              String warnMessage = "Got error response form SRS, status code: " + statusCode + ", status message: " + statusMessage;
+              logger.debug(warnMessage);
+              if (attemptsCount.get() <= 0) {
+                String errorMessage = "SRS didn't respond with expected status code after " + REQUEST_ATTEMPTS
+                    + " attempts. Canceling further request processing.";
+                srsClient.close();
+                handleException(promise, new IllegalStateException(errorMessage));
+                return;
+              }
+              logger.debug("Trying to request SRS again, attempts left: " + attemptsCount.decrementAndGet());
               srsClient.close();
-              handleException(promise, new IllegalStateException(errorMessage));
+              vertx.setTimer(REREQUEST_SRS_DELAY,
+                  timer -> doPostRequestToSrs(new SourceStorageSourceRecordsClient(srsClient), vertx, deletedRecordSupport, listOfIds, attemptsCount, promise));
+              return;
+            } if (statusCode != 200) {
+              String errorMsg = getErrorFromStorageMessage("source-record-storage", srsResponse.request()
+                .absoluteURI(), srsResponse.statusMessage());
+              srsClient.close();
+              handleException(promise, new IllegalStateException(errorMsg));
               return;
             }
-            logger.warn("Trying to request SRS again, attempts left: {}", attemptsCount.decrementAndGet());
-            vertx.setTimer(REREQUEST_SRS_DELAY, timer -> doPostRequestToSrs(srsClient, vertx, deletedRecordSupport, listOfIds, attemptsCount, promise));
-            return;
-          } else {
-            String errorMsg = getErrorFromStorageMessage("source-record-storage", srsResponse.request()
-              .absoluteURI(), srsResponse.statusMessage());
-            srsClient.close();
-            handleException(promise, new IllegalStateException(errorMsg));
-            return;
-          }
-        }
-        srsResponse.bodyHandler(getSrsResponseBodyHandler(srsClient, promise));
-      });
+            logger.info("Step 20.2Before srs body handler");
+            handleSrsResponse(srsClient, promise, buffer);
+          }));
     } catch (Exception e) {
       handleException(promise, e);
     }
   }
 
-  private Handler<Buffer> getSrsResponseBodyHandler(SourceStorageSourceRecordsClient srsClient, Promise<Map<String, JsonObject>> promise) {
-    return buffer -> {
-      final Map<String, JsonObject> result = Maps.newHashMap();
-      try {
-        final Object jsonResponse = buffer.toJson();
-        if (jsonResponse instanceof JsonObject) {
-          JsonObject entries = (JsonObject) jsonResponse;
-          final JsonArray records = entries.getJsonArray("sourceRecords");
-          records.stream()
-            .filter(Objects::nonNull)
-            .map(JsonObject.class::cast)
-            .forEach(jo -> result.put(jo.getJsonObject("externalIdsHolder")
-              .getString(INSTANCE_ID_FIELD_NAME), jo));
-        } else {
-          logger.debug("Can't process response from SRS: {}", buffer.toString());
-        }
-        promise.complete(result);
-      } catch (DecodeException ex) {
-        String msg = "Invalid json has been returned from SRS, cannot parse response to json.";
-        handleException(promise, new IllegalStateException(msg, ex));
-      } catch (Exception e) {
-        handleException(promise, e);
-      } finally {
-        srsClient.close();
+  private void handleSrsResponse(SourceStorageSourceRecordsClient srsClient, Promise<Map<String, JsonObject>> promise,
+      Buffer buffer) {
+    logger.info("Step 21");
+    final Map<String, JsonObject> result = Maps.newHashMap();
+    try {
+      final Object jsonResponse = buffer.toJson();
+      if (jsonResponse instanceof JsonObject) {
+        logger.info("Step 22");
+        JsonObject entries = (JsonObject) jsonResponse;
+        final JsonArray records = entries.getJsonArray("sourceRecords");
+        records.stream()
+          .filter(Objects::nonNull)
+          .map(JsonObject.class::cast)
+          .forEach(jo -> result.put(jo.getJsonObject("externalIdsHolder")
+            .getString(INSTANCE_ID_FIELD_NAME), jo));
+      } else {
+        logger.debug("Can't process response from SRS: {}", buffer.toString());
       }
-    };
+      logger.info("Step 23");
+      promise.complete(result);
+    } catch (DecodeException ex) {
+      String msg = "Invalid json has been returned from SRS, cannot parse response to json.";
+      handleException(promise, new IllegalStateException(msg, ex));
+    } catch (Exception e) {
+      handleException(promise, e);
+    } finally {
+      srsClient.close();
+    }
   }
 
   private String getErrorFromStorageMessage(String errorSource, String uri, String responseMessage) {

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -389,9 +389,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
       return;
     }
     instancesService.getRequestMetadataByRequestId(requestId, request.getTenant())
-      .compose(requestMetadata -> {
-        return Future.succeededFuture(requestMetadata.getStreamEnded());
-      })
+      .compose(requestMetadata -> Future.succeededFuture(requestMetadata.getStreamEnded()))
       .compose(streamEnded ->
       {
         if (firstBatch) {
@@ -723,9 +721,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
           handleException(promise, new IllegalStateException(errorMsg));
           return;
         }
-        srsResponse.bodyHandler(buffer -> {
-          handleSrsResponse(srsClient, promise, buffer);
-        });
+        srsResponse.bodyHandler(buffer -> handleSrsResponse(srsClient, promise, buffer));
       }, e->  retrySRSRequest(srsClient, vertx, deletedRecordSupport, listOfIds, attemptsCount, retryAttempts, promise, 400, "Error in SRS response"));
     } catch (Exception e) {
       handleException(promise, e);

--- a/src/main/resources/config/technical.json
+++ b/src/main/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\"}"
+  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\",\"httpRequestRetryAttempts\":\"50\"}"
 }

--- a/src/main/resources/config/technical.json
+++ b/src/main/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\",\"srsHttpRequestRetryAttempts\":\"50\"}"
+  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\",\"srsHttpRequestRetryAttempts\":\"50\",\"srsClientIdleTimeoutSec\":\"20\"}"
 }

--- a/src/main/resources/config/technical.json
+++ b/src/main/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\",\"httpRequestRetryAttempts\":\"50\"}"
+  "value" : "{\"maxRecordsPerResponse\":\"50\",\"enableValidation\":\"false\",\"formattedOutput\":\"false\",\"srsHttpRequestRetryAttempts\":\"50\"}"
 }

--- a/src/test/java/org/folio/oaipmh/helpers/RepositoryConfigurationUtilTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/RepositoryConfigurationUtilTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.folio.oaipmh.Request;
 import org.folio.rest.impl.OkapiMockServer;
@@ -33,8 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;

--- a/src/test/java/org/folio/oaipmh/helpers/response/ResponseHelperTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/response/ResponseHelperTest.java
@@ -1,5 +1,6 @@
 package org.folio.oaipmh.helpers.response;
 
+import static org.folio.oaipmh.Constants.REPOSITORY_ERRORS_PROCESSING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -183,7 +184,7 @@ class ResponseHelperTest {
   }
 
   private void setupErrorsProcessingSettingWithValue(String value) {
-    System.setProperty("repository.errorsProcessing", value);
+    System.setProperty(REPOSITORY_ERRORS_PROCESSING, value);
   }
 
   private Map<OAIPMHerrorcodeType, OAIPMH> buildOaipmhResponsesWithError() {

--- a/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
+++ b/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
@@ -46,7 +46,6 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
-@Disabled
 @ExtendWith(VertxExtension.class)
 @TestInstance(PER_CLASS)
 class CleanUpJobTest extends AbstractInstancesTest {

--- a/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
+++ b/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
@@ -24,8 +24,10 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.spring.SpringContextUtil;
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +46,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
+@Disabled
 @ExtendWith(VertxExtension.class)
 @TestInstance(PER_CLASS)
 class CleanUpJobTest extends AbstractInstancesTest {

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -19,6 +19,7 @@ import static org.folio.oaipmh.Constants.REPOSITORY_ADMIN_EMAILS;
 import static org.folio.oaipmh.Constants.REPOSITORY_BASE_URL;
 import static org.folio.oaipmh.Constants.REPOSITORY_DELETED_RECORDS;
 import static org.folio.oaipmh.Constants.REPOSITORY_ENABLE_OAI_SERVICE;
+import static org.folio.oaipmh.Constants.REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS;
 import static org.folio.oaipmh.Constants.REPOSITORY_MAX_RECORDS_PER_RESPONSE;
 import static org.folio.oaipmh.Constants.REPOSITORY_NAME;
 import static org.folio.oaipmh.Constants.REPOSITORY_STORAGE;
@@ -2182,7 +2183,9 @@ class OaiPmhImplTest {
   @Test
   void shouldRespondWithInternalServerError_whenGetOaiRecordsMarc21WithHoldingsWithErrorResponseFromSrs() {
     final String currentValue = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
+    final String retryAttempts = System.getProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS);
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "50");
+    System.setProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS, "1");
 
     RequestSpecification request = createBaseRequest()
       .with()
@@ -2196,9 +2199,10 @@ class OaiPmhImplTest {
       .statusCode(500)
       .extract()
       .asString();
-    String expectedMessage = format(EXPECTED_ERROR_MESSAGE, "source-record-storage");
+    String expectedMessage = "SRS didn't respond with expected status code after 1 attempts. Canceling further request processing.";
     assertTrue(body.contains(expectedMessage));
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, currentValue);
+    System.setProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS, retryAttempts);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -19,6 +19,7 @@ import static org.folio.oaipmh.Constants.REPOSITORY_ADMIN_EMAILS;
 import static org.folio.oaipmh.Constants.REPOSITORY_BASE_URL;
 import static org.folio.oaipmh.Constants.REPOSITORY_DELETED_RECORDS;
 import static org.folio.oaipmh.Constants.REPOSITORY_ENABLE_OAI_SERVICE;
+import static org.folio.oaipmh.Constants.REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC;
 import static org.folio.oaipmh.Constants.REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS;
 import static org.folio.oaipmh.Constants.REPOSITORY_MAX_RECORDS_PER_RESPONSE;
 import static org.folio.oaipmh.Constants.REPOSITORY_NAME;
@@ -38,6 +39,7 @@ import static org.folio.rest.impl.OkapiMockServer.DATE_INVENTORY_10_INSTANCE_IDS
 import static org.folio.rest.impl.OkapiMockServer.DATE_INVENTORY_STORAGE_ERROR_RESPONSE;
 import static org.folio.rest.impl.OkapiMockServer.DATE_SRS_500_ERROR_RESPONSE;
 import static org.folio.rest.impl.OkapiMockServer.DATE_SRS_ERROR_RESPONSE;
+import static org.folio.rest.impl.OkapiMockServer.DATE_SRS_IDLE_TIMEOUT_ERROR_RESPONSE;
 import static org.folio.rest.impl.OkapiMockServer.EMPTY_INSTANCES_IDS_DATE;
 import static org.folio.rest.impl.OkapiMockServer.INVALID_IDENTIFIER;
 import static org.folio.rest.impl.OkapiMockServer.INVALID_INSTANCE_IDS_JSON_DATE;
@@ -2178,6 +2180,23 @@ class OaiPmhImplTest {
 
     OAIPMH oaipmh = verify200WithXml(listRecordRequest, LIST_RECORDS);
     verifyListResponse(oaipmh, LIST_RECORDS, 1);
+  }
+
+  @Test
+  void shouldRerequestSrs_whenGetOaiRecordsMarc21WithHoldingsWithTimeoutErrorFromSrs() {
+    String idleTimeout = System.getProperty(REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC);
+    System.setProperty(REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC, "1");
+
+    RequestSpecification listRecordRequest = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, LIST_RECORDS.value())
+      .param(FROM_PARAM, DATE_SRS_IDLE_TIMEOUT_ERROR_RESPONSE)
+      .param(METADATA_PREFIX_PARAM, MetadataPrefix.MARC21WITHHOLDINGS.getName());
+
+    OAIPMH oaipmh = verify200WithXml(listRecordRequest, LIST_RECORDS);
+    verifyListResponse(oaipmh, LIST_RECORDS, 1);
+
+    System.setProperty(REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC, idleTimeout);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -19,7 +19,7 @@ import static org.folio.oaipmh.Constants.REPOSITORY_ADMIN_EMAILS;
 import static org.folio.oaipmh.Constants.REPOSITORY_BASE_URL;
 import static org.folio.oaipmh.Constants.REPOSITORY_DELETED_RECORDS;
 import static org.folio.oaipmh.Constants.REPOSITORY_ENABLE_OAI_SERVICE;
-import static org.folio.oaipmh.Constants.REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS;
+import static org.folio.oaipmh.Constants.REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS;
 import static org.folio.oaipmh.Constants.REPOSITORY_MAX_RECORDS_PER_RESPONSE;
 import static org.folio.oaipmh.Constants.REPOSITORY_NAME;
 import static org.folio.oaipmh.Constants.REPOSITORY_STORAGE;
@@ -2183,9 +2183,9 @@ class OaiPmhImplTest {
   @Test
   void shouldRespondWithInternalServerError_whenGetOaiRecordsMarc21WithHoldingsWithErrorResponseFromSrs() {
     final String currentValue = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
-    final String retryAttempts = System.getProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS);
+    final String retryAttempts = System.getProperty(REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS);
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "50");
-    System.setProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS, "1");
+    System.setProperty(REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS, "1");
 
     RequestSpecification request = createBaseRequest()
       .with()
@@ -2202,7 +2202,7 @@ class OaiPmhImplTest {
     String expectedMessage = "SRS didn't respond with expected status code after 1 attempts. Canceling further request processing.";
     assertTrue(body.contains(expectedMessage));
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, currentValue);
-    System.setProperty(REPOSITORY_HTTP_REQUEST_RETRY_ATTEMPTS, retryAttempts);
+    System.setProperty(REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS, retryAttempts);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -83,6 +83,7 @@ public class OkapiMockServer {
   static final String DATE_INVENTORY_STORAGE_ERROR_RESPONSE = "1488-01-02";
   static final String DATE_SRS_ERROR_RESPONSE = "1388-01-01";
   static final String DATE_SRS_500_ERROR_RESPONSE = "1388-02-02";
+  static final String DATE_SRS_IDLE_TIMEOUT_ERROR_RESPONSE = "1388-03-03";
   static final String DATE_INVENTORY_10_INSTANCE_IDS = "1499-01-01";
   static final String EMPTY_INSTANCES_IDS_DATE = "1444-01-01";
   static final String DATE_ERROR_FROM_ENRICHED_INSTANCES_VIEW = "1433-01-03";
@@ -98,6 +99,7 @@ public class OkapiMockServer {
   static final String TWO_RECORDS_WITH_ONE_INCONVERTIBLE_TO_XML_INSTANCE_ID = "7b6d9a58-ab67-414b-a33f-7db11ea16178";
   private static final String INSTANCE_ID_TO_MAKE_SRS_FAIL = "12345678-0000-4000-a000-000000000000";
   private static final String INSTANCE_ID_TO_MAKE_SRS_FAIL_WITH_500 = "927ee35f-700c-4fdd-a7e9-b560861d6900";
+  private static final String INSTANCE_ID_TO_MAKE_SRS_FAIL_BY_TIMEOUT = "d93c7b03-6343-4956-bfbc-2981b3741830";
   private static final String INSTANCE_ID_TO_FAIL_ENRICHED_INSTANCES_REQUEST = "22200000-0000-4000-a000-000000000000";
 
   // Paths to json files
@@ -139,6 +141,7 @@ public class OkapiMockServer {
   private static final String SRS_RESPONSE_TEMPLATE_JSON = "/srs_response_template.json";
   private static final String INSTANCE_ID_TO_MAKE_SRS_FAIL_JSON = "instance_id_to_make_srs_fail.json";
   private static final String INSTANCE_ID_TO_MAKE_SRS_FAIL_WITH_500_JSON = "instance_id_to_make_srs_fail_with_502.json";
+  private static final String INSTANCE_ID_SRS_TIMEOUT_JSON = "instance_id_to_make_srs_fail_with_timeout.json";
   private static final String EMPTY_INSTANCES_IDS_JSON = "empty_instances_ids.json";
   private static final String ERROR_FROM_ENRICHED_INSTANCES_IDS_JSON = "error_from_enrichedInstances_ids.json";
   private static final String INSTANCE_IDS = "instanceIds";
@@ -218,6 +221,8 @@ public class OkapiMockServer {
         inventoryViewSuccessResponse(ctx, INSTANCE_ID_TO_MAKE_SRS_FAIL_JSON);
       } else if (uri.contains(DATE_SRS_500_ERROR_RESPONSE)) {
         inventoryViewSuccessResponse(ctx, INSTANCE_ID_TO_MAKE_SRS_FAIL_WITH_500_JSON);
+      } else if (uri.contains(DATE_SRS_IDLE_TIMEOUT_ERROR_RESPONSE)) {
+        inventoryViewSuccessResponse(ctx, INSTANCE_ID_SRS_TIMEOUT_JSON);
       }else if (uri.contains(EMPTY_INSTANCES_IDS_DATE)) {
         inventoryViewSuccessResponse(ctx, EMPTY_INSTANCES_IDS_JSON);
       } else if (uri.contains(DATE_ERROR_FROM_ENRICHED_INSTANCES_VIEW)) {
@@ -309,6 +314,14 @@ public class OkapiMockServer {
       if(attemptsCount > 0) {
         attemptsCount--;
         failureResponse(ctx, 502, "Bad Gateway");
+      } else {
+        attemptsCount = 1;
+        successResponse(ctx, generateSrsPostResponseForInstanceIds(instanceIds));
+      }
+    } else if (instanceIds.contains(INSTANCE_ID_TO_MAKE_SRS_FAIL_BY_TIMEOUT)) {
+      if(attemptsCount > 0) {
+        attemptsCount--;
+        vertx.setTimer(20000, timerId -> successResponse(ctx, ""));
       } else {
         successResponse(ctx, generateSrsPostResponseForInstanceIds(instanceIds));
       }

--- a/src/test/resources/config/technical.json
+++ b/src/test/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false,\"srsHttpRequestRetryAttempts\":\"50\"}"
+  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false,\"srsHttpRequestRetryAttempts\":\"50\",\"srsClientIdleTimeoutSec\":\"20\"}"
 }

--- a/src/test/resources/config/technical.json
+++ b/src/test/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false,\"httpRequestRetryAttempts\":\"50\"}"
+  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false,\"srsHttpRequestRetryAttempts\":\"50\"}"
 }

--- a/src/test/resources/config/technical.json
+++ b/src/test/resources/config/technical.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "technical",
   "enabled" : true,
-  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false}"
+  "value" : "{\"maxRecordsPerResponse\":\"100\",\"enableValidation\":false,\"formattedOutput\":false,\"httpRequestRetryAttempts\":\"50\"}"
 }

--- a/src/test/resources/inventory_view/instance_id_to_make_srs_fail_with_timeout.json
+++ b/src/test/resources/inventory_view/instance_id_to_make_srs_fail_with_timeout.json
@@ -1,0 +1,1 @@
+{  "instanceId": "d93c7b03-6343-4956-bfbc-2981b3741830", "source": "FOLIO", "updatedDate": "2020-06-15T11:07:48.563Z",  "deleted": "false",  "suppressFromDiscovery": "false"}


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-300
Jira: https://issues.folio.org/browse/MODOAIPMH-301

### PURPOSE
Fix issue with the hanging of srs response handler which caused the harvest to be canceled. 
The root cause is that when srs responds with a large response body it may hang for an unknown reason and the body is not written to the response, therefore we can get the body and invoke body handler which causes the code hanging and canceling harvesting as result.

### APPROCH

Set the idle timeout of srs request to 20 seconds (instead of 5000) in order to invoke the exception handler (by causing timeout exception) when there a problem with receiving response body from SRS. Make a retry of srs call in the exception handler. 
