### PR TITLE
MODOAIPMH-310: Stabilize oai-pmh tests for release.

### DIFF
--- a/src/main/java/org/folio/oaipmh/Request.java
+++ b/src/main/java/org/folio/oaipmh/Request.java
@@ -195,6 +195,10 @@ public class Request {
     return nextInstancePkValue;
   }
 
+  public void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
+
   public String getRequestId() {
     return requestId;
   }

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -61,8 +61,8 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
     final SourceStorageSourceRecordsClient srsClient = new SourceStorageSourceRecordsClient(request.getOkapiUrl(),
       request.getTenant(), request.getOkapiToken());
 
-    final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
-    final boolean suppressedRecordsSupport = getBooleanProperty(request.getOkapiHeaders(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
+    final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId());
+    final boolean suppressedRecordsSupport = getBooleanProperty(request.getRequestId(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
     final Date updatedAfter = request.getFrom() == null ? null : convertStringToDate(request.getFrom(), false, true);
     final Date updatedBefore = request.getUntil() == null ? null : convertStringToDate(request.getUntil(), true, true);
@@ -152,7 +152,7 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
    * otherwise empty map is returned
    */
   private Map<String, RecordType> buildRecords(Context context, Request request, JsonArray instances) {
-    final boolean suppressedRecordsProcessingEnabled = getBooleanProperty(request.getOkapiHeaders(),
+    final boolean suppressedRecordsProcessingEnabled = getBooleanProperty(request.getRequestId(),
       REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
     if (instances != null && !instances.isEmpty()) {
@@ -196,7 +196,7 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
     RecordType record = new RecordType()
       .withHeader(createHeader(instance, request)
         .withIdentifier(getIdentifier(identifierPrefix, identifierId)));
-    if (isDeletedRecordsEnabled(request) && storageHelper.isRecordMarkAsDeleted(instance)) {
+    if (isDeletedRecordsEnabled(request.getRequestId()) && storageHelper.isRecordMarkAsDeleted(instance)) {
       record.getHeader().setStatus(StatusType.DELETED);
     }
     return record;

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiMetadataFormatsHelper.java
@@ -40,8 +40,8 @@ public class GetOaiMetadataFormatsHelper extends AbstractHelper {
 
     Promise<javax.ws.rs.core.Response> promise = Promise.promise();
     try {
-      final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
-      final boolean suppressedRecordsSupport = getBooleanProperty(request.getOkapiHeaders(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
+      final boolean deletedRecordsSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId());
+      final boolean suppressedRecordsSupport = getBooleanProperty(request.getRequestId(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
       final SourceStorageSourceRecordsClient srsClient = new SourceStorageSourceRecordsClient(request.getOkapiUrl(),
         request.getTenant(), request.getOkapiToken());

--- a/src/main/java/org/folio/oaipmh/helpers/GetOaiRepositoryInfoHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/GetOaiRepositoryInfoHelper.java
@@ -2,7 +2,6 @@ package org.folio.oaipmh.helpers;
 
 import static org.folio.oaipmh.Constants.DEFLATE;
 import static org.folio.oaipmh.Constants.GZIP;
-import static org.folio.oaipmh.Constants.OKAPI_TENANT;
 import static org.folio.oaipmh.Constants.REPOSITORY_ADMIN_EMAILS;
 import static org.folio.oaipmh.Constants.REPOSITORY_DELETED_RECORDS;
 import static org.folio.oaipmh.Constants.REPOSITORY_NAME;
@@ -47,18 +46,17 @@ public class GetOaiRepositoryInfoHelper extends AbstractHelper {
   public Future<Response> handle(Request request, Context ctx) {
     Promise<Response> promise = Promise.promise();
     try {
-      String tenant = request.getOkapiHeaders().get(OKAPI_TENANT);
       OAIPMH oai = getResponseHelper().buildBaseOaipmhResponse(request)
         .withIdentify(new IdentifyType()
-          .withRepositoryName(getRepositoryName(tenant))
+          .withRepositoryName(getRepositoryName(request.getRequestId()))
           .withBaseURL(request.getOaiRequest().getValue())
           .withProtocolVersion(REPOSITORY_PROTOCOL_VERSION_2_0)
           .withEarliestDatestamp(getEarliestDatestamp())
           .withGranularity(GranularityType.fromValue(RepositoryConfigurationUtil.getProperty
-            (tenant, REPOSITORY_TIME_GRANULARITY)))
+            (request.getRequestId(), REPOSITORY_TIME_GRANULARITY)))
           .withDeletedRecord(DeletedRecordType.fromValue(RepositoryConfigurationUtil
-            .getProperty(tenant, REPOSITORY_DELETED_RECORDS)))
-          .withAdminEmails(getEmails(tenant))
+            .getProperty(request.getRequestId(), REPOSITORY_DELETED_RECORDS)))
+          .withAdminEmails(getEmails(request.getRequestId()))
           .withCompressions(GZIP, DEFLATE)
           .withDescriptions(getDescriptions(request)));
 
@@ -85,8 +83,8 @@ public class GetOaiRepositoryInfoHelper extends AbstractHelper {
    *
    * @return repository name
    */
-  private String getRepositoryName(String tenant) {
-    String repoName = RepositoryConfigurationUtil.getProperty(tenant, REPOSITORY_NAME);
+  private String getRepositoryName(String requestId) {
+    String repoName = RepositoryConfigurationUtil.getProperty(requestId, REPOSITORY_NAME);
     if (repoName == null) {
       throw new IllegalStateException("The required repository config 'repository.name' is missing");
     }
@@ -99,8 +97,8 @@ public class GetOaiRepositoryInfoHelper extends AbstractHelper {
    *
    * @return repository name
    */
-  private String[] getEmails(String tenant) {
-    String emails = RepositoryConfigurationUtil.getProperty(tenant, REPOSITORY_ADMIN_EMAILS);
+  private String[] getEmails(String requestId) {
+    String emails = RepositoryConfigurationUtil.getProperty(requestId, REPOSITORY_ADMIN_EMAILS);
     if (StringUtils.isBlank(emails)) {
       throw new IllegalStateException("The required repository config 'repository.adminEmails' is missing");
     }

--- a/src/main/java/org/folio/oaipmh/helpers/RepositoryConfigurationUtil.java
+++ b/src/main/java/org/folio/oaipmh/helpers/RepositoryConfigurationUtil.java
@@ -12,13 +12,10 @@ import static org.openarchives.oai._2.DeletedRecordType.TRANSIENT;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.oaipmh.Request;
 import org.folio.oaipmh.helpers.configuration.ConfigurationHelper;
 import org.folio.rest.client.ConfigurationsClient;
-import org.folio.rest.tools.utils.TenantTool;
 import org.openarchives.oai._2.DeletedRecordType;
 
 import io.vertx.core.Future;

--- a/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/MarcWithHoldingsRequestHelper.java
@@ -159,8 +159,8 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
         .setLastUpdatedDate(lastUpdateDate);
 
       Future<RequestMetadataLb> updateRequestMetadataFuture;
-      if (resumptionToken == null || request.getRequestId() == null) {
-        requestId = UUID.randomUUID().toString();
+      if (resumptionToken == null) {
+        requestId = request.getRequestId();
         requestMetadata.setRequestId(UUID.fromString(requestId));
         updateRequestMetadataFuture = instancesService.saveRequestMetadata(requestMetadata, request.getTenant());
       } else {
@@ -194,7 +194,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
 
   private void processBatch(Request request, Context context, Promise<Response> oaiPmhResponsePromise, String requestId, boolean firstBatch) {
     try {
-      boolean deletedRecordSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request);
+      boolean deletedRecordSupport = RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId());
       int batchSize = Integer.parseInt(
         RepositoryConfigurationUtil.getProperty(request.getTenant(),
           REPOSITORY_MAX_RECORDS_PER_RESPONSE));
@@ -301,7 +301,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
     }
     paramMap.put(DELETED_RECORD_SUPPORT_PARAM_NAME,
       String.valueOf(
-        RepositoryConfigurationUtil.isDeletedRecordsEnabled(request)));
+        RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId())));
     paramMap.put(SKIP_SUPPRESSED_FROM_DISCOVERY_RECORDS,
       String.valueOf(
         isSkipSuppressed(request)));
@@ -531,7 +531,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
       boolean deletedRecordSupport) {
     RecordMetadataManager metadataManager = RecordMetadataManager.getInstance();
 
-    final boolean suppressedRecordsProcessing = getBooleanProperty(request.getOkapiHeaders(),
+    final boolean suppressedRecordsProcessing = getBooleanProperty(request.getRequestId(),
         REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
 
     List<RecordType> records = new ArrayList<>();
@@ -608,7 +608,7 @@ public class MarcWithHoldingsRequestHelper extends AbstractHelper {
   }
 
   private boolean isSkipSuppressed(Request request) {
-    return !getBooleanProperty(request.getOkapiHeaders(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
+    return !getBooleanProperty(request.getRequestId(), REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -1267,18 +1267,6 @@ class OaiPmhImplTest {
     });
   }
 
-  @Test
-  void shouldUseValidConfigValueAndDoNotSkipSuppressedRecords_whenGetListRecordsMarc21WithHoldings() {
-    RequestSpecification request = createBaseRequest()
-      .with()
-      .param(VERB_PARAM, LIST_RECORDS.value())
-      .param(FROM_PARAM, SUPPRESSED_RECORDS_DATE)
-      .param(METADATA_PREFIX_PARAM, MetadataPrefix.MARC21WITHHOLDINGS.getName());
-
-    OAIPMH response = verify200WithXml(request, LIST_RECORDS);
-    verifyListResponse(response, LIST_RECORDS, 10);
-  }
-
   @ParameterizedTest
   @EnumSource(value = VerbType.class, names = { "LIST_IDENTIFIERS", "LIST_RECORDS" })
   void getOaiIdentifiersWithErrorFromStorage(VerbType verb) {


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-310

### PURPOSE

Since oai-pmh can process several requests at once they all share the common configMap which is incorrect. The reason is that each upcoming request loads the config and overrides its values each time which can be already in use by handlers in separate threads. 
Each request should have its own config set in configMap as it was when we were using vertxContext config.
As well the "shouldUseValidConfigValueAndDoNotSkipSuppressedRecords_whenGetListRecordsMarc21WithHoldings" was removed for the reason that it should test logic with real third-party service like mod-config and we already have such an integration test at the folio-integration-tests project.
