### PR TITLE
MODOAIPMH-327: Resumption token flow doesn't work as expected for marc21 and oai_dc metadata prefixes

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -12,7 +12,6 @@ import static org.folio.oaipmh.Constants.LIST_NO_REQUIRED_PARAM_ERROR;
 import static org.folio.oaipmh.Constants.NEXT_RECORD_ID_PARAM;
 import static org.folio.oaipmh.Constants.NO_RECORD_FOUND_ERROR;
 import static org.folio.oaipmh.Constants.OFFSET_PARAM;
-import static org.folio.oaipmh.Constants.OKAPI_TENANT;
 import static org.folio.oaipmh.Constants.REPOSITORY_MAX_RECORDS_PER_RESPONSE;
 import static org.folio.oaipmh.Constants.REPOSITORY_SUPPRESSED_RECORDS_PROCESSING;
 import static org.folio.oaipmh.Constants.REPOSITORY_TIME_GRANULARITY;

--- a/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractHelper.java
@@ -350,7 +350,7 @@ public abstract class AbstractHelper implements VerbHelper {
    */
   protected ResumptionTokenType buildResumptionToken(Request request, JsonArray instances, Integer totalRecords) {
     int newOffset = request.getOffset() + Integer.parseInt(RepositoryConfigurationUtil.getProperty
-      (request.getOkapiHeaders().get(OKAPI_TENANT), REPOSITORY_MAX_RECORDS_PER_RESPONSE));
+      (request.getRequestId(), REPOSITORY_MAX_RECORDS_PER_RESPONSE));
     String resumptionToken = request.isRestored() ? EMPTY : null;
     if (newOffset < totalRecords) {
       Map<String, String> extraParams = new HashMap<>();

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2438,8 +2438,8 @@ class OaiPmhImplTest {
     ResumptionTokenType resumptionToken = getResumptionToken(oaipmh, verb);
     assertThat(resumptionToken, is(notNullValue()));
     assertThat(resumptionToken.getValue(), is(notNullValue()));
-    assertEquals(resumptionToken.getCompleteListSize(), BigInteger.valueOf(10));
-    assertEquals(resumptionToken.getCursor(), BigInteger.valueOf(0));
+    assertEquals(resumptionToken.getCompleteListSize(), BigInteger.TEN);
+    assertEquals(resumptionToken.getCursor(), BigInteger.ZERO);
 
     List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
     List<HeaderType> totalRecords = new ArrayList<>(records);
@@ -2447,7 +2447,7 @@ class OaiPmhImplTest {
     resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
 
     resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 2, 8);
-    assertThat(resumptionToken.getValue(), is(isEmptyString()));
+    assertThat(resumptionToken.getValue(), isEmptyString());
 
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, maxRecordsPerResponse);
   }
@@ -2486,35 +2486,30 @@ class OaiPmhImplTest {
 
   private ResumptionTokenType makeResumptionTokenRequestsAndVerifyCount(List<HeaderType> totalRecords,
       ResumptionTokenType resumptionToken, VerbType verb, int desiredCount, int expectedCursor) {
-    RequestSpecification request;
-    OAIPMH oaipmh;
-    List<HeaderType> records;
-    request = createBaseRequest().with()
+    RequestSpecification request = createBaseRequest().with()
       .param(VERB_PARAM, verb.value())
       .param(RESUMPTION_TOKEN_PARAM, resumptionToken.getValue());
+    OAIPMH oaipmh;
+    List<HeaderType> records;
     oaipmh = verify200WithXml(request, verb);
     verifyListResponse(oaipmh, verb, desiredCount);
     resumptionToken = getResumptionToken(oaipmh, verb);
     assertThat(resumptionToken, is(notNullValue()));
     assertEquals(expectedCursor, resumptionToken.getCursor()
       .intValue());
-
     records = getHeadersListDependOnVerbType(verb, oaipmh);
     totalRecords.addAll(records);
     return resumptionToken;
   }
 
   private List<HeaderType> getHeadersListDependOnVerbType(VerbType verb, OAIPMH oaipmh) {
-    if (verb.equals(LIST_RECORDS)) {
-      return oaipmh.getListRecords()
-        .getRecords()
-        .stream()
-        .map(RecordType::getHeader)
-        .collect(Collectors.toList());
-    } else {
-      return oaipmh.getListIdentifiers()
-        .getHeaders();
-    }
+    return verb.equals(LIST_RECORDS) ? oaipmh.getListRecords()
+      .getRecords()
+      .stream()
+      .map(RecordType::getHeader)
+      .collect(Collectors.toList()) :
+      oaipmh.getListIdentifiers()
+      .getHeaders();
   }
 
   @Autowired

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2501,12 +2501,13 @@ class OaiPmhImplTest {
   }
 
   private List<HeaderType> getHeadersListDependOnVerbType(VerbType verb, OAIPMH oaipmh) {
-    return verb.equals(LIST_RECORDS) ? oaipmh.getListRecords()
+    return verb.equals(LIST_RECORDS) 
+      ? oaipmh.getListRecords()
       .getRecords()
       .stream()
       .map(RecordType::getHeader)
-      .collect(Collectors.toList()) :
-      oaipmh.getListIdentifiers()
+      .collect(Collectors.toList()) 
+      : oaipmh.getListIdentifiers()
       .getHeaders();
   }
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2441,8 +2441,7 @@ class OaiPmhImplTest {
     assertEquals(BigInteger.TEN, resumptionToken.getCompleteListSize());
     assertEquals(BigInteger.ZERO, resumptionToken.getCursor());
 
-    List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
-    List<HeaderType> totalRecords = new ArrayList<>(records);
+    List<HeaderType> totalRecords = getHeadersListDependOnVerbType(verb, oaipmh);
 
     resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
 
@@ -2470,8 +2469,7 @@ class OaiPmhImplTest {
     assertThat(resumptionToken, is(notNullValue()));
     assertThat(resumptionToken.getValue(), is(notNullValue()));
     assertEquals(0, resumptionToken.getCursor().intValue());
-    List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
-    List<HeaderType> totalRecords = new ArrayList<>(records);
+    List<HeaderType> totalRecords = getHeadersListDependOnVerbType(verb, oaipmh);
 
     resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
 

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -36,6 +36,7 @@ import static org.folio.oaipmh.Constants.UNTIL_PARAM;
 import static org.folio.oaipmh.Constants.VERB_PARAM;
 import static org.folio.rest.impl.OkapiMockServer.DATE_ERROR_FROM_ENRICHED_INSTANCES_VIEW;
 import static org.folio.rest.impl.OkapiMockServer.DATE_FOR_INSTANCES_10;
+import static org.folio.rest.impl.OkapiMockServer.DATE_FOR_INSTANCES_10_PARTIALLY;
 import static org.folio.rest.impl.OkapiMockServer.DATE_INVENTORY_10_INSTANCE_IDS;
 import static org.folio.rest.impl.OkapiMockServer.INVENTORY_60_INSTANCE_IDS_DATE;
 import static org.folio.rest.impl.OkapiMockServer.DATE_INVENTORY_STORAGE_ERROR_RESPONSE;
@@ -2422,12 +2423,42 @@ class OaiPmhImplTest {
   }
 
   @ParameterizedTest
+  @MethodSource("metadataPrefixAndVerbProviderExceptMarc21withHoldings")
+  void verifyResumptionTokenFlowForMarc21AndOaiDcMetadataPrefixes(MetadataPrefix prefix, VerbType verb) {
+    String maxRecordsPerResponse = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
+    System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "4");
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, verb.value())
+      .param(METADATA_PREFIX_PARAM, prefix.getName())
+      .param(FROM_PARAM, DATE_FOR_INSTANCES_10_PARTIALLY);
+
+    OAIPMH oaipmh = verify200WithXml(request, verb);
+    verifyListResponse(oaipmh, verb, 4);
+    ResumptionTokenType resumptionToken = getResumptionToken(oaipmh, verb);
+    assertThat(resumptionToken, is(notNullValue()));
+    assertThat(resumptionToken.getValue(), is(notNullValue()));
+    assertEquals(resumptionToken.getCompleteListSize(), BigInteger.valueOf(10));
+    assertEquals(resumptionToken.getCursor(), BigInteger.valueOf(0));
+
+    List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
+    List<HeaderType> totalRecords = new ArrayList<>(records);
+
+    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
+
+    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb,2, 8);
+    assertThat(resumptionToken.getValue(), is(isEmptyString()));
+
+    System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, maxRecordsPerResponse);
+  }
+
+  @ParameterizedTest
   @EnumSource(value = VerbType.class, names = {"LIST_RECORDS"})
   void verifyResumptionTokenFlow_whenVerbListRecordsAndMetadataPrefixMarc21WithHoldings(VerbType verb) {
     final String currentValue = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "4");
 
-    List<HeaderType> totalRecords = new ArrayList<>();
     RequestSpecification request = createBaseRequest()
       .with()
       .param(VERB_PARAM, verb.value())
@@ -2440,14 +2471,12 @@ class OaiPmhImplTest {
     assertThat(resumptionToken, is(notNullValue()));
     assertThat(resumptionToken.getValue(), is(notNullValue()));
     assertEquals(0, resumptionToken.getCursor().intValue());
-    List<HeaderType> records = oaipmh.getListRecords().getRecords().stream()
-      .map(RecordType::getHeader)
-      .collect(Collectors.toList());
-    totalRecords.addAll(records);
+    List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
+    List<HeaderType> totalRecords = new ArrayList<>(records);
 
-    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, 4, 4);
+    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
 
-    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, 2, 8);
+    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 2, 8);
 
     assertThat(resumptionToken.getValue(), is(isEmptyString()));
 
@@ -2457,25 +2486,36 @@ class OaiPmhImplTest {
   }
 
   private ResumptionTokenType makeResumptionTokenRequestsAndVerifyCount(List<HeaderType> totalRecords,
-                                                                        ResumptionTokenType resumptionToken, int desiredCount, int expectedCursor) {
+      ResumptionTokenType resumptionToken, VerbType verb, int desiredCount, int expectedCursor) {
     RequestSpecification request;
     OAIPMH oaipmh;
     List<HeaderType> records;
-    request = createBaseRequest()
-      .with()
-      .param(VERB_PARAM, LIST_RECORDS.value())
+    request = createBaseRequest().with()
+      .param(VERB_PARAM, verb.value())
       .param(RESUMPTION_TOKEN_PARAM, resumptionToken.getValue());
-    oaipmh = verify200WithXml(request, LIST_RECORDS);
-    verifyListResponse(oaipmh, LIST_RECORDS, desiredCount);
-    resumptionToken = getResumptionToken(oaipmh, LIST_RECORDS);
+    oaipmh = verify200WithXml(request, verb);
+    verifyListResponse(oaipmh, verb, desiredCount);
+    resumptionToken = getResumptionToken(oaipmh, verb);
     assertThat(resumptionToken, is(notNullValue()));
-    assertEquals(expectedCursor, resumptionToken.getCursor().intValue());
+    assertEquals(expectedCursor, resumptionToken.getCursor()
+      .intValue());
 
-    records = oaipmh.getListRecords().getRecords().stream()
-      .map(RecordType::getHeader)
-      .collect(Collectors.toList());
+    records = getHeadersListDependOnVerbType(verb, oaipmh);
     totalRecords.addAll(records);
     return resumptionToken;
+  }
+
+  private List<HeaderType> getHeadersListDependOnVerbType(VerbType verb, OAIPMH oaipmh) {
+    if (verb.equals(LIST_RECORDS)) {
+      return oaipmh.getListRecords()
+        .getRecords()
+        .stream()
+        .map(RecordType::getHeader)
+        .collect(Collectors.toList());
+    } else {
+      return oaipmh.getListIdentifiers()
+        .getHeaders();
+    }
   }
 
   @Autowired

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2438,8 +2438,8 @@ class OaiPmhImplTest {
     ResumptionTokenType resumptionToken = getResumptionToken(oaipmh, verb);
     assertThat(resumptionToken, is(notNullValue()));
     assertThat(resumptionToken.getValue(), is(notNullValue()));
-    assertEquals(resumptionToken.getCompleteListSize(), BigInteger.TEN);
-    assertEquals(resumptionToken.getCursor(), BigInteger.ZERO);
+    assertEquals(BigInteger.TEN, resumptionToken.getCompleteListSize());
+    assertEquals(BigInteger.ZERO, resumptionToken.getCursor());
 
     List<HeaderType> records = getHeadersListDependOnVerbType(verb, oaipmh);
     List<HeaderType> totalRecords = new ArrayList<>(records);

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2428,8 +2428,7 @@ class OaiPmhImplTest {
     String maxRecordsPerResponse = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "4");
 
-    RequestSpecification request = createBaseRequest()
-      .with()
+    RequestSpecification request = createBaseRequest().with()
       .param(VERB_PARAM, verb.value())
       .param(METADATA_PREFIX_PARAM, prefix.getName())
       .param(FROM_PARAM, DATE_FOR_INSTANCES_10_PARTIALLY);
@@ -2447,7 +2446,7 @@ class OaiPmhImplTest {
 
     resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 4, 4);
 
-    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb,2, 8);
+    resumptionToken = makeResumptionTokenRequestsAndVerifyCount(totalRecords, resumptionToken, verb, 2, 8);
     assertThat(resumptionToken.getValue(), is(isEmptyString()));
 
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, maxRecordsPerResponse);

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.oaipmh.Constants.ILL_POLICIES_URI;
 import static org.folio.oaipmh.Constants.INSTANCE_FORMATS_URI;
@@ -23,6 +24,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -169,8 +171,10 @@ public class OkapiMockServer {
   private static final String INSTANCE_ID_UNDERLYING_RECORD_WITH_CYRILLIC_DATA = "ebbb759a-dd08-4bf8-b3c3-3d75b2190c41";
   private static final String INSTANCE_ID_WITHOUT_SRS_RECORD = "3a6a47ab-597d-4abe-916d-e31c723426d3";
 
-  private static final String REPLACE_WITH_RECORDS = "replace_with_records";
-  private static final String REPLACE_TOTAL_COUNT = "replace_total_count";
+  private static final String JSON_TEMPLATE_KEY_RECORDS = "replace_with_records";
+  private static final String JSON_TEMPLATE_KEY_TOTAL_COUNT = "replace_total_count";
+  private static final int LAST_RECORDS_BATCH_OFFSET_VALUE = 8;
+  private static final int LIMIT_VALUE_FOR_LAST_TWO_RECORDS_IN_JSON = 2;
 
   private static int srsRerequestAttemptsCount = 4;
   private static int totalSrsRerequestCallsNumber = 0;
@@ -297,19 +301,19 @@ public class OkapiMockServer {
     switch (ctx.request()
       .getHeader(OKAPI_TENANT)) {
     case EXIST_CONFIG_TENANT:
-      successResponse(ctx, getJsonObjectFromFile(CONFIG_TEST));
+      successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_TEST));
       break;
     case EXIST_CONFIG_TENANT_2:
-      successResponse(ctx, getJsonObjectFromFile(CONFIG_OAI_TENANT));
+      successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_OAI_TENANT));
       break;
     case INVALID_CONFIG_TENANT:
-      successResponse(ctx, getJsonObjectFromFile(CONFIG_WITH_INVALID_VALUE_FOR_DELETED_RECORDS));
+      successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_WITH_INVALID_VALUE_FOR_DELETED_RECORDS));
       break;
     case OAI_TEST_TENANT:
       if (ctx.request().absoluteURI().contains(SUPPRESSED_RECORDS_DATE)) {
-        successResponse(ctx, getJsonObjectFromFile(CONFIG_OAI_TENANT_PROCESS_SUPPRESSED_RECORDS));
+        successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_OAI_TENANT_PROCESS_SUPPRESSED_RECORDS));
       } else {
-        successResponse(ctx, getJsonObjectFromFile(CONFIG_OAI_TENANT));
+        successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_OAI_TENANT));
       }
       break;
     case ERROR_TENANT:
@@ -319,13 +323,13 @@ public class OkapiMockServer {
       successResponse(ctx, "&&@^$%^@$^&$");
       break;
     default:
-      successResponse(ctx, getJsonObjectFromFile(CONFIG_EMPTY));
+      successResponse(ctx, getJsonObjectFromFileAsString(CONFIG_EMPTY));
       break;
     }
   }
 
   private void handleSourceRecordStorageResponse(RoutingContext ctx) {
-    String json = getJsonObjectFromFile(String.format("/source-storage/records/%s", String.format("marc-%s.json", JSON_FILE_ID)));
+    String json = getJsonObjectFromFileAsString(String.format("/source-storage/records/%s", String.format("marc-%s.json", JSON_FILE_ID)));
     if (isNotEmpty(json)) {
       final String uri = ctx.request()
         .absoluteURI();
@@ -337,10 +341,10 @@ public class OkapiMockServer {
       } else if (uri.contains(THREE_INSTANCES_DATE)) {
         json = getRecordJsonWithSuppressedTrue(getRecordJsonWithDeletedTrue(json));
       } else if (uri.contains(NO_RECORDS_DATE)) {
-        json = getJsonObjectFromFile("/instance-storage.instances" + "/instances_0.json");
+        json = getJsonObjectFromFileAsString("/instance-storage.instances" + "/instances_0.json");
       } else if (ctx.request()
         .method() == HttpMethod.POST) {
-        json = getJsonObjectFromFile("/source-storage/records/srs_instances.json");
+        json = getJsonObjectFromFileAsString("/source-storage/records/srs_instances.json");
       }
       successResponse(ctx, json);
     } else {
@@ -372,15 +376,15 @@ public class OkapiMockServer {
         successResponse(ctx, generateSrsPostResponseForInstanceIds(instanceIds));
       }
     } else if (instanceIds.contains(INVALID_SRS_RECORD_INSTANCE_ID)) {
-      successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_WITH_INVALID_JSON));
+      successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_WITH_INVALID_JSON));
     } else if (instanceIds.contains(TWO_RECORDS_WITH_ONE_INCONVERTIBLE_TO_XML_INSTANCE_ID)) {
-      successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_ONE_CANNOT_BE_CONVERTED_TO_XML_JSON));
+      successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_ONE_CANNOT_BE_CONVERTED_TO_XML_JSON));
     } else if (instanceIds.contains(DEFAULT_INSTANCE_ID)) {
-      successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
+      successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
     } else if (instanceIds.contains(INSTANCE_ID_UNDERLYING_RECORD_WITH_CYRILLIC_DATA)) {
-      successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_WITH_CYRILLIC_DATA_JSON));
+      successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_WITH_CYRILLIC_DATA_JSON));
     } else if (instanceIds.contains(INSTANCE_ID_WITHOUT_SRS_RECORD)) {
-      successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
+      successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
     } else {
       String mockSrsResponse = generateSrsPostResponseForInstanceIds(instanceIds);
       successResponse(ctx, mockSrsResponse);
@@ -392,52 +396,52 @@ public class OkapiMockServer {
       .absoluteURI();
     if (uri != null) {
       if (uri.contains(DEFAULT_RECORD_DATE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
       } else if (uri.contains(String.format("%s=%s", ID_PARAM, EXISTING_IDENTIFIER))) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_1));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_1));
       } else if (uri.contains(String.format("%s=%s", ID_PARAM, NON_EXISTING_IDENTIFIER))) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
       } else if (uri.contains(NO_RECORDS_DATE_STORAGE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_0));
       } else if (uri.contains(String.format("%s=%s", ID_PARAM, ERROR_IDENTIFIER))) {
         failureResponse(ctx, 500, "Internal Server Error");
       } else if (uri.contains(ERROR_UNTIL_DATE_STORAGE)) {
         failureResponse(ctx, 500, "Internal Server Error");
       } else if (uri.contains(PARTITIONABLE_RECORDS_DATE_TIME_STORAGE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_11));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_11));
       } else if (uri.contains(DATE_FOR_ONE_INSTANCE_BUT_WITHOT_RECORD_STORAGE) || uri.contains(NOT_FOUND_RECORD_INSTANCE_ID)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_1_NO_RECORD_SOURCE));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_1_NO_RECORD_SOURCE));
       } else if (uri.contains(RECORD_STORAGE_INTERNAL_SERVER_ERROR_UNTIL_DATE_STORAGE)) {
         failureResponse(ctx, 500, "Internal Server Error");
       } else if (uri.contains(THREE_INSTANCES_DATE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_3));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_3));
       } else if (uri.contains(DATE_FOR_FOUR_INSTANCES_BUT_ONE_WITHOT_RECORD_STORAGE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_4));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_4));
       } else if (uri.contains(DATE_FOR_FOUR_INSTANCES_BUT_ONE_WITHOUT__EXTERNAL_IDS_HOLDER_FIELD_STORAGE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_3_LAST_WITHOUT_EXTERNAL_IDS_HOLDER_FIELD));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_3_LAST_WITHOUT_EXTERNAL_IDS_HOLDER_FIELD));
       } else if (uri.contains(DATE_FOR_INSTANCES_10)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_10));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_10));
       } else if (uri.contains(DATE_FOR_INSTANCES_10_PARTIALLY)) {
         int offset = parseInt(ctx.request().getParam("offset"));
         int limit = parseInt(ctx.request().getParam("limit"));
-        successResponse(ctx, getSrsRecordsPartially(offset, limit));
+        successResponse(ctx, getSrsRecordsPartially(ctx.request().params()));
       } else if (uri.contains(THREE_INSTANCES_DATE_WITH_ONE_MARK_DELETED_RECORD)) {
-        String json = getJsonWithRecordMarkAsDeleted(getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_3));
+        String json = getJsonWithRecordMarkAsDeleted(getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_3));
         successResponse(ctx, json);
       } else if (uri.contains(SRS_RECORD_WITH_INVALID_JSON_STRUCTURE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_WITH_INVALID_JSON));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_WITH_INVALID_JSON));
       } else if (uri.contains(TWO_RECORDS_WITH_ONE_INCONVERTIBLE_TO_XML)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_ONE_CANNOT_BE_CONVERTED_TO_XML_JSON));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_ONE_CANNOT_BE_CONVERTED_TO_XML_JSON));
       } else if (uri.contains(SRS_RECORDS_WITH_CYRILLIC_DATA_DATE)) {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_WITH_CYRILLIC_DATA_JSON));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + TWO_RECORDS_WITH_CYRILLIC_DATA_JSON));
       } else if (uri.contains(SRS_RECORD_WITH_OLD_METADATA_DATE)) {
-        String json = getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RECORD);
+        String json = getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD);
         successResponse(ctx, json.replaceAll("REPLACE_ME", OLD_METADATA_DATE_FORMAT));
       } else if (uri.contains(SRS_RECORD_WITH_NEW_METADATA_DATE)) {
-        String json = getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RECORD);
+        String json = getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD);
         successResponse(ctx, json.replaceAll("REPLACE_ME", NEW_METADATA_DATE_FORMAT));
       } else {
-        successResponse(ctx, getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_11));
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_11));
       }
       logger.info("Mock returns http status code: " + ctx.response()
         .getStatusCode());
@@ -446,35 +450,43 @@ public class OkapiMockServer {
     }
   }
 
-  private String getSrsRecordsPartially(int offset, int limit) {
-    String sourceRecordsString = requireNonNull(getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_10));
-    String srsRecordsResponseTemplate = requireNonNull(getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RESPONSE_TEMPLATE_JSON));
-    JsonObject sourceRecordsJson = new JsonObject(sourceRecordsString);
-    JsonArray defaultRecords = sourceRecordsJson.getJsonArray("sourceRecords");
-    JsonArray requiredRecords = new JsonArray();
-    int interval = offset == 8 ? 2 : limit;
-    for (int i = 0; i < interval; i++) {
+  private String getSrsRecordsPartially(MultiMap params) {
+    try {
+      int offset = parseInt(requireNonNull(params.get("offset")));
+      int limit = parseInt(requireNonNull(params.get("limit")));
+      String sourceRecordsString = requireNonNull(getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_10_TOTAL_RECORDS_10));
+      String srsRecordsResponseTemplate = requireNonNull(getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RESPONSE_TEMPLATE_JSON));
+      JsonObject sourceRecordsJson = new JsonObject(sourceRecordsString);
+      JsonArray defaultRecords = sourceRecordsJson.getJsonArray("sourceRecords");
+      JsonArray requiredRecords = new JsonArray();
+      int interval = offset == LAST_RECORDS_BATCH_OFFSET_VALUE ? LIMIT_VALUE_FOR_LAST_TWO_RECORDS_IN_JSON : limit;
+      for (int i = 0; i < interval; i++) {
         requiredRecords.add(defaultRecords.getJsonObject(offset + i));
+      }
+      String requiredRecordsArray = requiredRecords.encode();
+      requiredRecordsArray = requiredRecordsArray.substring(1, requiredRecordsArray.length() - 1);
+      String response = srsRecordsResponseTemplate.replaceAll(JSON_TEMPLATE_KEY_RECORDS, requiredRecordsArray);
+      return response.replaceAll(JSON_TEMPLATE_KEY_TOTAL_COUNT, "10");
+    } catch (Exception ex) {
+      logger.error("Can't obtain the offset/limit params. " + ex.getMessage());
+      fail(ex);
     }
-    String requiredRecordsArray = requiredRecords.encode();
-    requiredRecordsArray = requiredRecordsArray.substring(1, requiredRecordsArray.length()-1);
-    String response = srsRecordsResponseTemplate.replaceAll(REPLACE_WITH_RECORDS, requiredRecordsArray);
-    return response.replaceAll(REPLACE_TOTAL_COUNT, "10");
+    return EMPTY;
   }
 
   private void handleInventoryStorageFilteringConditionsResponse(RoutingContext ctx) {
     String uri = ctx.request()
       .absoluteURI();
     if (uri.contains(ILL_POLICIES_URI)) {
-      successResponse(ctx, getJsonObjectFromFile(ILL_POLICIES_JSON_PATH));
+      successResponse(ctx, getJsonObjectFromFileAsString(ILL_POLICIES_JSON_PATH));
     } else if (uri.contains(INSTANCE_FORMATS_URI)) {
-      successResponse(ctx, getJsonObjectFromFile(INSTANCE_FORMATS_JSON_PATH));
+      successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_FORMATS_JSON_PATH));
     } else if (uri.contains(RESOURCE_TYPES_URI)) {
-      successResponse(ctx, getJsonObjectFromFile(INSTANCE_TYPES_JSON_PATH));
+      successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_TYPES_JSON_PATH));
     } else if (uri.contains(LOCATION_URI)) {
-      successResponse(ctx, getJsonObjectFromFile(LOCATION_JSON_PATH));
+      successResponse(ctx, getJsonObjectFromFileAsString(LOCATION_JSON_PATH));
     } else if (uri.contains(MATERIAL_TYPES_URI)) {
-      successResponse(ctx, getJsonObjectFromFile(MATERIAL_TYPES_JSON_PATH));
+      successResponse(ctx, getJsonObjectFromFileAsString(MATERIAL_TYPES_JSON_PATH));
     } else {
       failureResponse(ctx, 400, "there is no mocked handler for request uri '{" + uri + "}'");
     }
@@ -491,7 +503,7 @@ public class OkapiMockServer {
   private void inventoryViewSuccessResponse(RoutingContext routingContext, String jsonFileName) {
     String path = INVENTORY_VIEW_PATH + jsonFileName;
     logger.debug("Logger: Path value: " + path);
-    Buffer buffer = Buffer.buffer(getJsonObjectFromFile(path));
+    Buffer buffer = Buffer.buffer(getJsonObjectFromFileAsString(path));
     logger.debug("Ending response for instance ids with buffer: " + buffer.toString());
     routingContext.response().setStatusCode(200).end(buffer);
   }
@@ -527,7 +539,7 @@ public class OkapiMockServer {
    * @param path path to json file to read
    * @return json as string from the json file
    */
-  private String getJsonObjectFromFile(String path) {
+  private String getJsonObjectFromFileAsString(String path) {
     try {
       logger.debug("Loading file " + path);
       URL resource = OkapiMockServer.class.getResource(path);
@@ -557,7 +569,7 @@ public class OkapiMockServer {
   }
 
   private String generateEnrichedInstancesResponse(JsonArray instancesIds) {
-    String enrichedInstanceTemplate = requireNonNull(getJsonObjectFromFile(INVENTORY_VIEW_PATH + ENRICHED_INSTANCE_TEMPLATE_JSON));
+    String enrichedInstanceTemplate = requireNonNull(getJsonObjectFromFileAsString(INVENTORY_VIEW_PATH + ENRICHED_INSTANCE_TEMPLATE_JSON));
     List<String> enrichedInstances = instancesIds.stream()
       .map(Object::toString)
       .map(instanceId ->  enrichedInstanceTemplate.replace("set_instance_id", instanceId)
@@ -571,16 +583,16 @@ public class OkapiMockServer {
   }
 
   private String generateSrsPostResponseForInstanceIds(JsonArray instanceIds) {
-    String srsRecordTemplate = requireNonNull(getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_TEMPLATE_JSON));
+    String srsRecordTemplate = requireNonNull(getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_TEMPLATE_JSON));
     String srsRecordsResponseTemplate = requireNonNull(
-      getJsonObjectFromFile(SOURCE_STORAGE_RESULT_URI + SRS_RESPONSE_TEMPLATE_JSON));
+      getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RESPONSE_TEMPLATE_JSON));
     List<String> srsRecords = new ArrayList<>();
     instanceIds.stream()
       .map(Object::toString)
       .forEach(id -> srsRecords.add(transformTemplateToRecord(requireNonNull(srsRecordTemplate), id)));
     String allRecords = String.join(",", srsRecords);
-    return srsRecordsResponseTemplate.replace(REPLACE_WITH_RECORDS, allRecords)
-      .replace(REPLACE_TOTAL_COUNT, String.valueOf(srsRecords.size()));
+    return srsRecordsResponseTemplate.replace(JSON_TEMPLATE_KEY_RECORDS, allRecords)
+      .replace(JSON_TEMPLATE_KEY_TOTAL_COUNT, String.valueOf(srsRecords.size()));
   }
 
   private String transformTemplateToRecord(String recordTemplate, String instanceId) {


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-327

### PURPOSE
Fix issue with resumption token flow work for marc21 and oai_dc metadata prefixes.

### APPROACH
At previous commits, the way for using configurations was changed to use the request_id instead of tenant_id and one place wasn't adjusted to the new approach and this caused the issue. So, the code was adjusted to use request id. Parameterized unit test added.