### PR TITLE
MODOAIPMH-337: The mod-oai-pmh schema is not populated correctly after RMB 32 update. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,24 @@
         <artifactId>vertx-pg-client</artifactId>
         <version>${vertx.version}-FOLIO</version>
       </dependency>
+      <dependency> <!-- needed for mockserver-client-java -->
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.65.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.7.0-RC1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.15.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -131,21 +145,21 @@
     <aspectj.version>1.9.6</aspectj.version>
     <raml-module-builder.version>33.0.2</raml-module-builder.version>
     <vertx.version>4.1.0</vertx.version>
-    <vertx-folio.version>3.9.4-FOLIO</vertx-folio.version>
+    <vertx-folio.version>4.1.0-FOLIO</vertx-folio.version>
     <apache-httpclient.version>4.5.11</apache-httpclient.version>
     <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
     <time-adapters.version>1.1.3</time-adapters.version>
     <jaxb2-basics.version>1.11.1</jaxb2-basics.version>
     <marc4j.version>2.9.1</marc4j.version>
     <mod-configuration-client.version>5.7.0</mod-configuration-client.version>
-    <mod-source-record-storage-client.version>5.0.0</mod-source-record-storage-client.version>
+    <mod-source-record-storage-client.version>5.1.2</mod-source-record-storage-client.version>
     <log4j-slf4j.version>2.13.0</log4j-slf4j.version>
     <restassured.version>4.3.0</restassured.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
     <jooq.version>3.14.11</jooq.version>
     <vertx-jooq.generator.version>6.3.0</vertx-jooq.generator.version>
     <vertx-jooq.classic-reactive.version>6.3.0</vertx-jooq.classic-reactive.version>
-    <postgres.version>42.2.12</postgres.version>
+    <postgres.version>42.2.23</postgres.version>
   </properties>
 
   <dependencies>
@@ -286,6 +300,22 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mockserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>5.11.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-osgi</artifactId>
       <version>2.3.0.1</version>
@@ -295,11 +325,12 @@
       <groupId>org.folio</groupId>
       <artifactId>postgres-testing</artifactId>
       <version>${raml-module-builder.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.20</version>
+      <version>${postgres.version}</version>
     </dependency>
 
   </dependencies>
@@ -313,6 +344,7 @@
     </resources>
 
     <plugins>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
@@ -561,6 +593,7 @@
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
+                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>
@@ -784,6 +817,21 @@
           </generator>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-
 import javax.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
@@ -24,8 +23,10 @@ import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.client.ConfigurationsClient;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.folio.spring.SpringContextUtil;
+import org.glassfish.jersey.message.internal.Statuses;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -53,6 +54,8 @@ public class ModTenantAPI extends TenantAPI {
   private static final String MODULE_NAME = "OAIPMH";
   private static final int CONFIG_JSON_BODY = 0;
 
+  static final String CONFIG_PATH_KEY = "configPath";
+
   private ConfigurationHelper configurationHelper;
 
   public ModTenantAPI() {
@@ -70,20 +73,20 @@ public class ModTenantAPI extends TenantAPI {
         Future<String> initDatabaseFuture = initDatabase(headers, context.owner());
         GenericCompositeFuture.all(List.of(loadConfigurationDataFuture, initDatabaseFuture))
           .onComplete(future -> {
-            String message;
             if (future.succeeded()) {
-              message = loadConfigurationDataFuture.result() + " " + initDatabaseFuture.result();
+              String message = loadConfigurationDataFuture.result() + " " + initDatabaseFuture.result();
+              handlers.handle(Future.succeededFuture(buildResponse(message)));
             } else {
-              message = getResultErrorMessage(loadConfigurationDataFuture, initDatabaseFuture);
+              String message = future.cause().getMessage();
+              logger.error(message, future.cause());
+              handlers.handle(Future.failedFuture(new ResponseException(buildErrorResponse(message))));
             }
-            handlers.handle(Future.succeededFuture(buildResponse(message)));
           });
       }
     }, context);
   }
 
   private Future<String> loadConfigurationData(Map<String, String> headers) {
-    Promise<String> promise = Promise.promise();
     List<String> configsSet = Arrays.asList("behavior", "general", "technical");
 
     String okapiUrl = headers.get(OKAPI_URL);
@@ -93,22 +96,17 @@ public class ModTenantAPI extends TenantAPI {
     WebClient webClient = WebClient.create(VertxUtils.getVertxFromContextOrNew());
     ConfigurationsClient client = new ConfigurationsClient(okapiUrl, tenant, token, webClient);
 
-    List<Future> futures = new ArrayList<>();
+    List<Future<String>> futures = new ArrayList<>();
 
     configsSet.forEach(configName -> futures.add(processConfigurationByConfigName(configName, client)));
-    GenericCompositeFuture.all(futures)
-      .onComplete(future -> {
-        String message;
-        if (future.succeeded()) {
-          message = "Configurations has been set up successfully";
-        } else {
-          message = Optional.ofNullable(future.cause())
-            .map(Throwable::getMessage)
-            .orElse("Error has been occurred while communicating to mod-configuration");
+    return GenericCompositeFuture.all(futures)
+      .map("Configuration has been set up successfully")
+      .recover(e -> {
+        if (e.getMessage() == null) {
+          e = new RuntimeException("Error has been occurred while communicating to mod-configuration", e);
         }
-        promise.complete(message);
+        return Future.failedFuture(e);
       });
-    return promise.future();
   }
 
   private Future<String> processConfigurationByConfigName(String configName, ConfigurationsClient client) {
@@ -155,31 +153,34 @@ public class ModTenantAPI extends TenantAPI {
   }
 
   private void postConfig(ConfigurationsClient client, String configName, Promise<String> promise) {
-    Config config = new Config();
-    config.setConfigName(configName);
-    config.setEnabled(true);
-    config.setModule(MODULE_NAME);
-    config.setValue(getConfigValue(configName));
     try {
+      Config config = new Config();
+      config.setConfigName(configName);
+      config.setEnabled(true);
+      config.setModule(MODULE_NAME);
+      config.setValue(getConfigValue(configName));
       client.postConfigurationsEntries(null, config, result -> {
-        if (result.succeeded()) {
-          HttpResponse<Buffer> response = result.result();
-          if (response.statusCode() != 201) {
-            logger.error("Invalid responseonse from mod-configuration. Cannot post config '{}'. Response message: {} {}",
-                configName, response.statusCode(), response.statusMessage());
-            promise.fail(new IllegalStateException("Cannot post config. " + response.statusMessage()));
-          }
-          logger.info("Config {} posted successfully.", configName);
-        } else {
-          promise.fail(new IllegalStateException("Error occurred during config posting.", result.cause()));
+        if (result.failed()) {
+          Exception e = new IllegalStateException("Error occurred during config posting.", result.cause());
+          logger.error(e.getMessage(), e);
+          promise.fail(e);
+          return;
         }
+        HttpResponse<Buffer> response = result.result();
+        if (response.statusCode() != 201) {
+          logger.error("Invalid responseonse from mod-configuration. Cannot post config '{}'. Response message: {} {}",
+              configName, response.statusCode(), response.statusMessage());
+          promise.fail(new IllegalStateException("Cannot post config. " + response.statusMessage()));
+          return;
+        }
+        logger.info("Config {} posted successfully.", configName);
+        promise.complete();
       });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       promise.fail(e);
       return;
     }
-    promise.complete();
   }
 
   private void populateSystemPropertiesWithConfig(JsonObject jsonResponse) {
@@ -199,10 +200,9 @@ public class ModTenantAPI extends TenantAPI {
    */
   private String getConfigValue(String configName) {
     Properties systemProperties = System.getProperties();
-    String configPath = systemProperties.getProperty("configPath", CONFIG_DIR_PATH);
+    String configPath = systemProperties.getProperty(CONFIG_PATH_KEY, CONFIG_DIR_PATH);
     JsonObject jsonConfigEntry = configurationHelper.getJsonConfigFromResources(configPath, configName + ".json");
     Map<String, String> configKeyValueMap = configurationHelper.getConfigKeyValueMapFromJsonEntryValueField(jsonConfigEntry);
-
     JsonObject configEntryValueField = new JsonObject();
     configKeyValueMap.forEach((key, configDefaultValue) -> {
       String possibleJvmSpecifiedValue = systemProperties.getProperty(key);
@@ -230,33 +230,22 @@ public class ModTenantAPI extends TenantAPI {
         String message = Optional.ofNullable(result.cause())
           .map(Throwable::getMessage)
           .orElse("Failed to initialize the database");
-        logger.error(message);
-        promise.fail(message);
+        logger.error(message, result.cause());
+        promise.fail(new RuntimeException(message, result.cause()));
       }
     });
     return promise.future();
-  }
-
-  /**
-   * Returns error message of the first failed future. Since both futures required to be succeeded for enabling module for tenant
-   * then if one of them fails then there are no matter that the second future will be succeeded and therefore we don't need to wait
-   * until it will be completed and thus we should respond with message of the first failed future.
-   *
-   * @param configDataFuture - future of loading configuration data
-   * @param initDbFuture     - future of initializing the module database
-   * @return error message
-   */
-  private String getResultErrorMessage(Future<String> configDataFuture, Future<String> initDbFuture) {
-    if (configDataFuture.failed()) {
-      return configDataFuture.result();
-    }
-    return initDbFuture.result();
   }
 
   private Response buildResponse(String body) {
     Response.ResponseBuilder builder = Response.status(HttpStatus.SC_OK)
       .header(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_PLAIN.toString())
       .entity(body);
+    return builder.build();
+  }
+
+  private Response buildErrorResponse(String info) {
+    Response.ResponseBuilder builder = Response.status(Statuses.from(400, info));
     return builder.build();
   }
 

--- a/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
+++ b/src/test/java/org/folio/oaipmh/common/AbstractInstancesTest.java
@@ -68,15 +68,13 @@ public abstract class AbstractInstancesTest {
 
   @BeforeEach
   void setup(VertxTestContext testContext) {
-    List<Future> saveRequestMetadataFutures = new ArrayList<>();
+    List<Future<RequestMetadataLb>> saveRequestMetadataFutures = new ArrayList<>();
     requestMetadataList
       .forEach(elem -> saveRequestMetadataFutures.add(getInstancesDao().saveRequestMetadata(elem, OAI_TEST_TENANT)));
 
     GenericCompositeFuture.all(saveRequestMetadataFutures)
-      .onSuccess(v -> getInstancesDao().saveInstances(instancesList, OAI_TEST_TENANT)
-        .onSuccess(e -> testContext.completeNow())
-        .onFailure(testContext::failNow))
-      .onFailure(testContext::failNow);
+    .compose(v -> getInstancesDao().saveInstances(instancesList, OAI_TEST_TENANT))
+    .onComplete(testContext.succeedingThenComplete());
   }
 
   @AfterEach

--- a/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
+++ b/src/test/java/org/folio/rest/impl/CleanUpJobTest.java
@@ -99,15 +99,13 @@ class CleanUpJobTest extends AbstractInstancesTest {
       .post()
       .then()
       .statusCode(204);
-    verifyExpiredInstancesHasBeenCleared(testContext);
-  }
 
-  private void verifyExpiredInstancesHasBeenCleared(VertxTestContext testContext) {
-    instancesDao.getInstancesList(100, EXPIRED_REQUEST_ID, OAI_TEST_TENANT).onSuccess(instances -> {
+    instancesDao.getInstancesList(100, EXPIRED_REQUEST_ID, OAI_TEST_TENANT)
+    .onComplete(testContext.succeeding(instances -> {
       List<String> instancesIds = instances.stream().map(Instances::getInstanceId).map(UUID::toString).collect(Collectors.toList());
       assertFalse(instancesIds.contains(EXPIRED_INSTANCE_ID));
       testContext.completeNow();
-    }).onFailure(testContext::failNow);
+    }));
   }
 
   @Override

--- a/src/test/java/org/folio/rest/impl/ModTenantAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/ModTenantAPIIT.java
@@ -1,0 +1,94 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class ModTenantAPIIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ModTenantAPIIT.class);
+
+  private static final Network network = Network.newNetwork();
+
+  @Container
+  private static final GenericContainer<?> module =
+  new GenericContainer<>(new ImageFromDockerfile().withFileFromPath(".", Path.of(".")))
+  .withNetwork(network)
+  .withExposedPorts(8081)
+  .withEnv("DB_HOST", "postgres")
+  .withEnv("DB_PORT", "5432")
+  .withEnv("DB_USERNAME", "username")
+  .withEnv("DB_PASSWORD", "password")
+  .withEnv("DB_DATABASE", "postgres");
+
+  @Container
+  private final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:12-alpine")
+  .withNetwork(network)
+  .withNetworkAliases("postgres")
+  .withExposedPorts(5432)
+  .withUsername("username")
+  .withPassword("password")
+  .withDatabaseName("postgres");
+
+  @Container
+  private final MockServerContainer okapi =
+  new MockServerContainer(DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2"))
+  .withNetwork(network)
+  .withNetworkAliases("okapi")
+  .withExposedPorts(1080);
+
+  @BeforeEach
+  void beforeEach() {
+    module.followOutput(new Slf4jLogConsumer(LOGGER).withSeparateOutputStreams());
+    RestAssured.port = module.getFirstMappedPort();
+
+    var mockServerClient = new MockServerClient(okapi.getHost(), okapi.getServerPort());
+    mockServerClient.when(request().withMethod("POST"))
+    .respond(response().withStatusCode(201));
+    mockServerClient.when(request().withMethod("GET"))
+    .respond(response().withBody("{\"configs\":[]}", MediaType.JSON_UTF_8));
+
+    RestAssured.requestSpecification = new RequestSpecBuilder()
+        .addHeader("x-okapi-tenant", "ten")
+        .addHeader("x-okapi-url", "http://okapi:1080")
+        .setContentType(ContentType.JSON)
+        .build();
+  }
+
+  @Test
+  void test() {
+    given().
+      body("{ \"module_to\": \"99.99.99\" }").
+    when().
+      post("/_/tenant").
+    then().
+      statusCode(200);
+
+    when().
+      post("/oai-pmh/clean-up-instances").
+    then().
+      statusCode(204);
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/ModTenantAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/ModTenantAPIIT.java
@@ -35,6 +35,7 @@ class ModTenantAPIIT {
   private static final GenericContainer<?> module =
   new GenericContainer<>(new ImageFromDockerfile().withFileFromPath(".", Path.of(".")))
   .withNetwork(network)
+  .withNetworkAliases("module")
   .withExposedPorts(8081)
   .withEnv("DB_HOST", "postgres")
   .withEnv("DB_PORT", "5432")
@@ -61,7 +62,7 @@ class ModTenantAPIIT {
   @BeforeEach
   void beforeEach() {
     module.followOutput(new Slf4jLogConsumer(LOGGER).withSeparateOutputStreams());
-    RestAssured.port = module.getFirstMappedPort();
+    RestAssured.baseURI = "http://" + module.getHost() + ":" + module.getFirstMappedPort();
 
     var mockServerClient = new MockServerClient(okapi.getHost(), okapi.getServerPort());
     mockServerClient.when(request().withMethod("POST"))

--- a/src/test/java/org/folio/rest/impl/ModTenantAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ModTenantAPITest.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.Map;
@@ -36,7 +37,7 @@ class ModTenantAPITest {
     });
   }
 
-  Future<Void> okapiMock(Vertx vertx) {
+  Future<HttpServer> okapiMock(Vertx vertx) {
     return vertx.createHttpServer()
         .requestHandler(httpServerRequest -> {
           switch (httpServerRequest.method().toString()) {
@@ -49,8 +50,7 @@ class ModTenantAPITest {
           }
         })
         .listen(0)
-        .onSuccess(httpServer -> okapiPort = httpServer.actualPort())
-        .mapEmpty();
+        .onSuccess(httpServer -> okapiPort = httpServer.actualPort());
   }
 
   Map<String,String> headers() {

--- a/src/test/java/org/folio/rest/impl/ModTenantAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ModTenantAPITest.java
@@ -1,0 +1,79 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.Map;
+import java.util.TreeMap;
+import org.folio.config.ApplicationConfig;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.spring.SpringContextUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class ModTenantAPITest {
+
+  int okapiPort = -1;
+  Context context;
+  ModTenantAPI modTenantAPI;
+  TenantAttributes tenantAttributes = new TenantAttributes().withModuleTo("99.99.99");
+
+  void withModTenantAPI(Vertx vertx, VertxTestContext vtc, Runnable run) {
+    vertx.exceptionHandler(e -> {
+      e.printStackTrace();
+      vtc.failNow(e);
+    });
+    vertx.runOnContext(x -> {
+      context = vertx.getOrCreateContext();
+      SpringContextUtil.init(vertx, context, ApplicationConfig.class);
+      modTenantAPI = new ModTenantAPI();
+      SpringContextUtil.autowireDependencies(modTenantAPI, context);
+      okapiMock(vertx)
+      .onComplete(vtc.succeeding(y -> run.run()));
+    });
+  }
+
+  Future<Void> okapiMock(Vertx vertx) {
+    return vertx.createHttpServer()
+        .requestHandler(httpServerRequest -> {
+          switch (httpServerRequest.method().toString()) {
+          case "POST":
+            httpServerRequest.response().setStatusCode(201).end();
+            break;
+          default:
+            httpServerRequest.response().end("{\"configs\":[]}");
+            break;
+          }
+        })
+        .listen(0)
+        .onSuccess(httpServer -> okapiPort = httpServer.actualPort())
+        .mapEmpty();
+  }
+
+  Map<String,String> headers() {
+    var headers = new TreeMap<String,String>(String.CASE_INSENSITIVE_ORDER);
+    headers.put("x-okapi-url", "http://localhost:" + okapiPort);
+    headers.put("x-okapi-tenant", "diku");
+    return headers;
+  }
+
+  @Test
+  void postTenantShouldSucceed(Vertx vertx, VertxTestContext vtc) {
+    withModTenantAPI(vertx, vtc, () -> {
+      modTenantAPI.postTenant(tenantAttributes, headers(), vtc.succeedingThenComplete(), context);
+    });
+  }
+
+  @Test
+  void postTenantShouldFail_whenNoTenantId(Vertx vertx, VertxTestContext vtc) {
+    var headers = headers();
+    headers.remove("x-okapi-tenant");
+    withModTenantAPI(vertx, vtc, () -> {
+      modTenantAPI.postTenant(tenantAttributes, headers, vtc.failingThenComplete(), context);
+    });
+  }
+
+}

--- a/src/test/resources/config/behavior.json
+++ b/src/test/resources/config/behavior.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "behavior",
   "enabled" : true,
-  "value" : "{\"deletedRecordsSupport\":\"no\",\"suppressedRecordsProcessing\":false,\"errorsProcessing\":\"500\",\"test.prop\":\"Test Value\"}"
+  "value" : "{\"deletedRecordsSupport\":\"no\",\"suppressedRecordsProcessing\":false,\"errorsProcessing\":\"500\"}"
 }


### PR DESCRIPTION
ModTenantAPI should return a failure on exception.
There should be a unit test and an integration test for ModTenantAPI.

This pull request changes the code for proper exception reporting, and adds a unit test and an integration test.

The integration test uses a mod-oai-pmh docker container to ensure that the shaded jar and the Dockerfile create a working container.