### PR TITLE
MODOAIPMH-283 - provide effective location and effective call number data when item record is not present

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,8 @@
             "inventory-storage.oai-pmh-view.instances.collection.get",
             "inventory-storage.oai-pmh-view.updatedinstanceids.collection.get",
             "inventory-storage.oai-pmh-view.enrichedinstances.collection.post",
-            "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get"
+            "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get",
+            "inventory-storage.inventory-hierarchy.items-and-holdings.collection.post"
           ]
         },
         {


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODOAIPMH-283

### PURPOSE

The existing FOLIO implementation of the derived fields (effective location and effective call number) requires item records. The purpose of this story is to populate location and holdings information, following the logic of effective location/call number when the item data is not present.

