### PR TITLE
MODOAIPMH-393: Move health test from Jenkins file to integration test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,7 @@ buildMvn {
   doDocker = {
     buildJavaDocker {
       publishMaster = 'yes'
-      healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      // health check in ModTenantAPIIT
     }
   }
 }


### PR DESCRIPTION
The "Docker Build" stage in Jenkins takes 45 seconds. It builds the Docker container and runs the health test.

ModTenantAPIIT.java is an integration test that builds the Docker container.

Moving the health test from Jenkins into ModTenantAPIIT saves 44 seconds because the existing Docker container can be used.