### PR TITLE
MODOAIPMH-405 - Spike - Investigate mod-oai-pmh logs when debug mode is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following schemas used:
  + MARC 21 XML Schema: [MARC21slim.xsd](http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd) (please refer to [MARC 21 XML Schema](http://www.loc.gov/standards/marcxml/) for more details)
 ### Deployment requirements
 OAI-PMH is heavily loaded module and for correct work with big data set(approximately 4-5 millions records) it requires to have as least 400 Mb of java heap and 1Gb for docker container memory.
-It is required to set environment variables according to ModuleDescriptor: DB_QUERYTIMEOUT = 604800000, DB_MAXPOOLSIZE = 50.
+It is required to set environment variables according to ModuleDescriptor: DB_QUERYTIMEOUT = 2700000, DB_MAXPOOLSIZE = 35.
 ### Configuration
 Configuration properties are intended to be retrieved from [mod-configuration](https://github.com/folio-org/mod-configuration/blob/master/README.md) module. System property values are used as a fallback.
 Configurations can be managed from the UI through the mod-configuration via folio settings.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following schemas used:
  + MARC 21 XML Schema: [MARC21slim.xsd](http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd) (please refer to [MARC 21 XML Schema](http://www.loc.gov/standards/marcxml/) for more details)
 ### Deployment requirements
 OAI-PMH is heavily loaded module and for correct work with big data set(approximately 4-5 millions records) it requires to have as least 400 Mb of java heap and 1Gb for docker container memory.
+It is required to set environment variables according to ModuleDescriptor: DB_QUERYTIMEOUT = 604800000, DB_MAXPOOLSIZE = 50.
 ### Configuration
 Configuration properties are intended to be retrieved from [mod-configuration](https://github.com/folio-org/mod-configuration/blob/master/README.md) module. System property values are used as a fallback.
 Configurations can be managed from the UI through the mod-configuration via folio settings.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -212,9 +212,9 @@
       { "name": "DB_USERNAME", "value": "folio_admin" },
       { "name": "DB_PASSWORD", "value": "folio_admin" },
       { "name": "DB_DATABASE", "value": "okapi_modules" },
-      { "name": "DB_QUERYTIMEOUT", "value": "604800000" },
+      { "name": "DB_QUERYTIMEOUT", "value": "2700000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
-      { "name": "DB_MAXPOOLSIZE", "value": "50" }
+      { "name": "DB_MAXPOOLSIZE", "value": "35" }
     ]
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -214,7 +214,7 @@
       { "name": "DB_DATABASE", "value": "okapi_modules" },
       { "name": "DB_QUERYTIMEOUT", "value": "604800000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
-      { "name": "DB_MAXPOOLSIZE", "value": "20" }
+      { "name": "DB_MAXPOOLSIZE", "value": "50" }
     ]
   }
 }


### PR DESCRIPTION
[MODOAIPMH-405](https://issues.folio.org/browse/MODOAIPMH-405) - Spike - Investigate mod-oai-pmh logs when debug mode is enabled.

ENV variables should be increased according to the ModuleDescriptor.