### PR TITLE
MODOAIPMH-436 - Holdings without items have  always subfield t in 952 set to 1

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -1,5 +1,6 @@
 package org.folio.oaipmh.helpers.records;
 
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.oaipmh.Constants.CONTENT;
@@ -172,8 +173,7 @@ public class RecordMetadataManager {
                                                           boolean suppressedRecordsProcessing) {
     Map<String, Object> effectiveLocationSubFields = constructEffectiveLocationSubFieldsMap(itemData);
     if (suppressedRecordsProcessing) {
-      int subFieldValue = BooleanUtils.isFalse(itemData.getBoolean(INVENTORY_SUPPRESS_DISCOVERY_FIELD)) ? 0 : 1;
-      effectiveLocationSubFields.put(DISCOVERY_SUPPRESSED_SUBFIELD_CODE, subFieldValue);
+      effectiveLocationSubFields.put(DISCOVERY_SUPPRESSED_SUBFIELD_CODE, calculateDiscoverySuppressedSubfieldValue(itemData));
     }
     FieldBuilder fieldBuilder = new FieldBuilder();
     Map<String, Object> effectiveLocationField = fieldBuilder.withFieldTagNumber(EFFECTIVE_LOCATION_FILED_TAG_NUMBER)
@@ -182,6 +182,19 @@ public class RecordMetadataManager {
       .withSubFields(effectiveLocationSubFields)
       .build();
     marcRecordFields.add(effectiveLocationField);
+  }
+
+  /**
+   * Calculates discovery suppressed subfield value.
+   *
+   * @param itemData - json of single item
+   * @return subfield value
+   */
+  private int calculateDiscoverySuppressedSubfieldValue(JsonObject itemData) {
+    if (isNull(itemData.getBoolean(INVENTORY_SUPPRESS_DISCOVERY_FIELD))) {
+      return 0;
+    }
+    return BooleanUtils.isFalse(itemData.getBoolean(INVENTORY_SUPPRESS_DISCOVERY_FIELD)) ? 0 : 1;
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2327,6 +2327,45 @@ class OaiPmhImplTest {
   }
 
   @Test
+  void getOaiRecordsMarc21WithHoldingsWhenNoItemsWithSuppressedRecordsProcessing() {
+    String repositorySuppressDiscovery = System.getProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING);
+    System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, "true");
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, LIST_RECORDS.value())
+      .param(FROM_PARAM, NO_ITEMS_DATE)
+      .param(METADATA_PREFIX_PARAM, MARC21WITHHOLDINGS.getName());
+
+    OAIPMH response = verify200WithXml(request, LIST_RECORDS);
+
+    assertThat(response.getErrors(), is(empty()));
+    response.getListRecords().getRecords().forEach(r -> {
+      Optional<SubfieldatafieldType> optInstitutionName = findSubfieldByFiledTagAndSubfieldCode(r, "952", "a");
+      Optional<SubfieldatafieldType> optCampusName = findSubfieldByFiledTagAndSubfieldCode(r, "952", "b");
+      Optional<SubfieldatafieldType> optLibraryName = findSubfieldByFiledTagAndSubfieldCode(r, "952", "c");
+      Optional<SubfieldatafieldType> optLocationName = findSubfieldByFiledTagAndSubfieldCode(r, "952", "d");
+      Optional<SubfieldatafieldType> optCallNumber = findSubfieldByFiledTagAndSubfieldCode(r, "952", "e");
+      Optional<SubfieldatafieldType> optDiscoverySuppressed = findSubfieldByFiledTagAndSubfieldCode(r, "952", "t");
+      Optional<SubfieldatafieldType> optHoldingsUrlField = findSubfieldByFiledTagAndSubfieldCode(r, "856", "u");
+      Optional<SubfieldatafieldType> optHoldingsType = findSubfieldByFiledTagAndSubfieldCode(r, "856", "3");
+      Optional<SubfieldatafieldType> optHoldingsUrlNote = findSubfieldByFiledTagAndSubfieldCode(r, "856", "z");
+      assertTrue(optInstitutionName.isPresent());
+      assertTrue(optCampusName.isPresent());
+      assertTrue(optLibraryName.isPresent());
+      assertTrue(optLocationName.isPresent());
+      assertTrue(optCallNumber.isPresent());
+      assertTrue(optDiscoverySuppressed.isPresent());
+      assertThat(optDiscoverySuppressed.get().getValue(), equalTo("0"));
+      assertTrue(optHoldingsUrlField.isPresent());
+      assertTrue(optHoldingsType.isPresent());
+      assertTrue(optHoldingsUrlNote.isPresent());
+    });
+
+    System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, repositorySuppressDiscovery);
+  }
+
+  @Test
   void getOaiRecordsMarc21WithHoldingsReturnsCorrectXmlResponseWIthDefaultBatchSize() {
     final String currentValue = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "50");


### PR DESCRIPTION
[MODOAIPMH-436](https://issues.folio.org/browse/MODOAIPMH-436) - Holdings without items have  always subfield t in 952 set to 1

## Purpose
For holdings without items when the records are harvested with discovery flag the subfield t in 952 field is always set to 1 even if the holdings are not suppressed.

## Approach
* fixed harvesting logic
* updated unit test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
