### PR TITLE
MODOAIPMH-440: Support instance-storage 9.0 interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -132,7 +132,7 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.6 8.0"
+      "version": "7.6 8.0 9.0"
     },
     {
       "id": "source-storage-records",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-oai-pmh uses only instance-storage, it doesn't use the other two interfaces.

mod-oai-pmh is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-oai-pmh.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json