### PR TITLE
MODOAIPMH-460 - Make records source configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ OAI-PMH | `repository.errorsProcessing` | `500` | Defines in which way OAI-PMH l
 OAI-PMH | `repository.srsHttpRequestRetryAttempts` | `50`| Property is used in marc21_withholdings metadata prefix handler. If SRS returns an incorrect response then the same request will be sent again up to 50 times until the expected response will not be received or all 50 attempts will fail which leads to error response.
 OAI-PMH | `repository.srsClientIdleTimeoutSec` | `20` | The idle timeout for requests to SRS.
 OAI-PMH | `repository.fetchingChunkSize` | `5000` | The chunk size in batch processing.
+OAI-PMH | `repository.recordsSource` | `Source record storage` | Indicates from where instance records are retrieved. Other possible values: Inventory, Source record storage and Inventory.
 
 ### Configuration priority resolving
 TenantApi 'POST' implementation is responsible for getting configurations for a module from mod-configuration and adjusting them to system properties when posting module for tenant. Since there 3 places of configurations (mod-configuration, JVM, default form resources), there are ways of resolving configuration inconsistencies when TenantAPI executes. <br/>

--- a/src/main/java/org/folio/oaipmh/Constants.java
+++ b/src/main/java/org/folio/oaipmh/Constants.java
@@ -38,6 +38,7 @@ public final class Constants {
   public static final String REPOSITORY_ENABLE_OAI_SERVICE = "repository.enableOaiService";
   public static final String REPOSITORY_ERRORS_PROCESSING = "repository.errorsProcessing";
   public static final String REPOSITORY_FETCHING_CHUNK_SIZE = "repository.fetchingChunkSize";
+  public static final String REPOSITORY_RECORDS_SOURCE = "repository.recordsSource";
 
   public static final String SOURCE_RECORD_STORAGE = "SRS";
 

--- a/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
+++ b/src/main/java/org/folio/oaipmh/mappers/PropertyNameMapper.java
@@ -2,7 +2,6 @@ package org.folio.oaipmh.mappers;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.folio.oaipmh.Constants;
 
 import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_ENABLE_VALIDATION;
 import static org.folio.oaipmh.Constants.JAXB_MARSHALLER_FORMATTED_OUTPUT;
@@ -18,6 +17,7 @@ import static org.folio.oaipmh.Constants.REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC;
 import static org.folio.oaipmh.Constants.REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS;
 import static org.folio.oaipmh.Constants.REPOSITORY_SUPPRESSED_RECORDS_PROCESSING;
 import static org.folio.oaipmh.Constants.REPOSITORY_TIME_GRANULARITY;
+import static org.folio.oaipmh.Constants.REPOSITORY_RECORDS_SOURCE;
 
 /**
  * Mapper is used for mapping names of frontend property names to server names.
@@ -42,6 +42,7 @@ public class PropertyNameMapper {
     frontendToBackendMapper.put("srsHttpRequestRetryAttempts", REPOSITORY_SRS_HTTP_REQUEST_RETRY_ATTEMPTS);
     frontendToBackendMapper.put("srsClientIdleTimeoutSec", REPOSITORY_SRS_CLIENT_IDLE_TIMEOUT_SEC);
     frontendToBackendMapper.put("fetchingChunkSize", REPOSITORY_FETCHING_CHUNK_SIZE);
+    frontendToBackendMapper.put("recordsSource", REPOSITORY_RECORDS_SOURCE);
     frontendToBackendMapper.forEach((key, value) -> backendToFrontendMapper.put(value, key));
   }
 

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -146,8 +146,8 @@ public class ModTenantAPI extends TenantAPI {
     }
     JsonObject body = response.bodyAsJsonObject();
     JsonArray configs = body.getJsonArray(CONFIGS);
-    if (configs.isEmpty() || isRecordsSourceNotFound(configName, configs) || isFetchingChunkSizeNotFound(configName, configs)) {
-      logger.info("Configuration group with configName {} doesn't exist or incomplete. Posting default configs for {} configuration group.",
+    if (configs.isEmpty()) {
+      logger.info("Configuration group with configName {} doesn't exist. Posting default configs for {} configuration group.",
         MODULE_NAME, configName);
       postConfig(client, configName, promise);
     } else {
@@ -155,29 +155,6 @@ public class ModTenantAPI extends TenantAPI {
       populateSystemPropertiesWithConfig(body);
       promise.complete();
     }
-  }
-
-  private boolean isRecordsSourceNotFound(String configName, JsonArray configs) {
-    return isFieldNotFound(configName, configs, "behavior", "recordsSource");
-  }
-
-  private boolean isFetchingChunkSizeNotFound(String configName, JsonArray configs) {
-    return isFieldNotFound(configName, configs, "technical", "fetchingChunkSize");
-  }
-
-  private boolean isFieldNotFound(String configName, JsonArray configs, String requiredConfigName, String field) {
-    if (configName.equals(requiredConfigName)) {
-      for (Object config : configs) {
-        if (config instanceof JsonObject) {
-          JsonObject jsonObjectConfig = (JsonObject) config;
-          if (jsonObjectConfig.getString("configName").equals(configName)) {
-            JsonObject jsonObjectValue = new JsonObject(jsonObjectConfig.getString("value"));
-            return !jsonObjectValue.containsKey(field);
-          }
-        }
-      }
-    }
-    return false;
   }
 
   private void postConfig(ConfigurationsClient client, String configName, Promise<String> promise) {

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -146,8 +146,8 @@ public class ModTenantAPI extends TenantAPI {
     }
     JsonObject body = response.bodyAsJsonObject();
     JsonArray configs = body.getJsonArray(CONFIGS);
-    if (configs.isEmpty()) {
-      logger.info("Configuration group with configName {} doesn't exist. Posting default configs for {} configuration group.",
+    if (configs.isEmpty() || isRecordsSourceNotFound(configName, configs) || isFetchingChunkSizeNotFound(configName, configs)) {
+      logger.info("Configuration group with configName {} doesn't exist or incomplete. Posting default configs for {} configuration group.",
         MODULE_NAME, configName);
       postConfig(client, configName, promise);
     } else {
@@ -155,6 +155,29 @@ public class ModTenantAPI extends TenantAPI {
       populateSystemPropertiesWithConfig(body);
       promise.complete();
     }
+  }
+
+  private boolean isRecordsSourceNotFound(String configName, JsonArray configs) {
+    return isFieldNotFound(configName, configs, "behavior", "recordsSource");
+  }
+
+  private boolean isFetchingChunkSizeNotFound(String configName, JsonArray configs) {
+    return isFieldNotFound(configName, configs, "technical", "fetchingChunkSize");
+  }
+
+  private boolean isFieldNotFound(String configName, JsonArray configs, String requiredConfigName, String field) {
+    if (configName.equals(requiredConfigName)) {
+      for (Object config : configs) {
+        if (config instanceof JsonObject) {
+          JsonObject jsonObjectConfig = (JsonObject) config;
+          if (jsonObjectConfig.getString("configName").equals(configName)) {
+            JsonObject jsonObjectValue = new JsonObject(jsonObjectConfig.getString("value"));
+            return !jsonObjectValue.containsKey(field);
+          }
+        }
+      }
+    }
+    return false;
   }
 
   private void postConfig(ConfigurationsClient client, String configName, Promise<String> promise) {

--- a/src/main/resources/config/behavior.json
+++ b/src/main/resources/config/behavior.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "behavior",
   "enabled" : true,
-  "value" : "{\"deletedRecordsSupport\":\"persistent\",\"suppressedRecordsProcessing\":\"true\",\"errorsProcessing\":\"200\"}"
+  "value" : "{\"deletedRecordsSupport\":\"persistent\",\"suppressedRecordsProcessing\":\"true\",\"errorsProcessing\":\"200\",\"recordsSource\":\"Source record storage\"}"
 }

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -81,8 +81,6 @@ class InitAPIsTest {
       assertNotNull(System.getProperty(BEHAVIOUR_GROUP_TEST_CONFIG));
       assertNotNull(System.getProperty(GENERAL_GROUP_TEST_CONFIG));
       assertNotNull(System.getProperty(TECHNICAL_GROUP_TEST_CONFIG));
-      JsonObject jsonConfigBehavior = ConfigurationHelper.getInstance().getJsonConfigFromResources("config", "behavior.json");
-      assertEquals("Source record storage", new JsonObject(jsonConfigBehavior.getString("value")).getString("recordsSource"));
       verifyJaxbInitialized();
       logger.info("shouldInitSuccessfully_whenDefaultConfigFilePathAndConfigFilesPropertyValuesAreUsed finished");
       testContext.completeNow();

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -20,8 +20,6 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
-import java.util.Map;
-
 @ExtendWith(VertxExtension.class)
 class InitAPIsTest {
 

--- a/src/test/java/org/folio/rest/impl/InitAPIsTest.java
+++ b/src/test/java/org/folio/rest/impl/InitAPIsTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.oaipmh.ResponseConverter;
+import org.folio.oaipmh.helpers.configuration.ConfigurationHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.DecodeException;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+
+import java.util.Map;
 
 @ExtendWith(VertxExtension.class)
 class InitAPIsTest {
@@ -77,8 +81,23 @@ class InitAPIsTest {
       assertNotNull(System.getProperty(BEHAVIOUR_GROUP_TEST_CONFIG));
       assertNotNull(System.getProperty(GENERAL_GROUP_TEST_CONFIG));
       assertNotNull(System.getProperty(TECHNICAL_GROUP_TEST_CONFIG));
+      JsonObject jsonConfigBehavior = ConfigurationHelper.getInstance().getJsonConfigFromResources("config", "behavior.json");
+      assertEquals("Source record storage", new JsonObject(jsonConfigBehavior.getString("value")).getString("recordsSource"));
       verifyJaxbInitialized();
       logger.info("shouldInitSuccessfully_whenDefaultConfigFilePathAndConfigFilesPropertyValuesAreUsed finished");
+      testContext.completeNow();
+    }));
+  }
+
+  @Test
+  void shouldAddRecordsSourceDefaultValueSuccessfully_whenDefaultConfigFilePathAndConfigFilesPropertyValuesAreUsed(Vertx vertx, VertxTestContext testContext) {
+    System.clearProperty(CONFIGURATION_PATH);
+    System.clearProperty(CONFIGURATION_FILES);
+    new InitAPIs().init(vertx, vertx.getOrCreateContext(), testContext.succeeding(result -> {
+      assertTrue(result);
+      JsonObject jsonConfigBehavior = ConfigurationHelper.getInstance().getJsonConfigFromResources("config", "behavior.json");
+      assertEquals("Source record storage", new JsonObject(jsonConfigBehavior.getString("value")).getString("recordsSource"));
+      verifyJaxbInitialized();
       testContext.completeNow();
     }));
   }

--- a/src/test/resources/config/behavior.json
+++ b/src/test/resources/config/behavior.json
@@ -2,5 +2,5 @@
   "module" : "OAIPMH",
   "configName" : "behavior",
   "enabled" : true,
-  "value" : "{\"deletedRecordsSupport\":\"no\",\"suppressedRecordsProcessing\":false,\"errorsProcessing\":\"500\"}"
+  "value" : "{\"deletedRecordsSupport\":\"no\",\"suppressedRecordsProcessing\":false,\"errorsProcessing\":\"500\",\"recordsSource\":\"Source record storage\"}"
 }


### PR DESCRIPTION
[MODOAIPMH-460](https://issues.folio.org/browse/MODOAIPMH-460) - Make records source configurable

## Purpose
In order to increase OAI-PMH module flexibility, records_source parameter is intended to be added to OAI-PMH settings.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
