### PR TITLE
MODOAIPMH-473 - "856" field is omitted in responce for Electronic access relationship type created by user

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -47,6 +47,8 @@ public class RecordMetadataManager {
   private static final int SECOND_INDICATOR_INDEX = 1;
   private static final String LOCATION = "location";
 
+  private static final String DEFAULT_INDICATORS = "4, ";
+
   private StorageHelper storageHelper = StorageHelper.getInstance();
   private final Map<String, String> indicatorsMap;
   private final Predicate<JsonObject> generalInfoFieldPredicate;
@@ -66,11 +68,11 @@ public class RecordMetadataManager {
   private RecordMetadataManager() {
     indicatorsMap = new HashMap<>();
     indicatorsMap.put("No display constant generated", "4,8");
-    indicatorsMap.put("", "4, ");
+    indicatorsMap.put("", DEFAULT_INDICATORS);
     indicatorsMap.put("Related resource", "4,2");
     indicatorsMap.put("Resource", "4,0");
     indicatorsMap.put("Version of resource", "4,1");
-    indicatorsMap.put("No information provided", "4, ");
+    indicatorsMap.put("No information provided", DEFAULT_INDICATORS);
 
     generalInfoFieldPredicate = jsonObject -> {
       if (jsonObject.containsKey(GENERAL_INFO_FIELD_TAG_NUMBER)) {
@@ -240,7 +242,7 @@ public class RecordMetadataManager {
   private List<String> resolveIndicatorsValue(JsonObject electronicAccess) {
     String name = electronicAccess.getString(NAME);
     String key = StringUtils.isNotEmpty(name) ? name : EMPTY;
-    String indicatorsInString = indicatorsMap.get(key);
+    String indicatorsInString = indicatorsMap.getOrDefault(key, DEFAULT_INDICATORS);
     if (indicatorsInString != null) {
       return Arrays.asList(indicatorsInString.split(","));
     } else {

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -62,6 +62,7 @@ class RecordMetadataManagerTest {
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_RELATED_RESOURCE = "/metadata-manager/electronic_access-related_resource.json";
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_RESOURCE = "/metadata-manager/electronic_access-resource.json";
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_VERSION_OF_RESOURCE = "/metadata-manager/electronic_access-version_of_resource.json";
+  private static final String ITEM_WITH_ELECTRONIC_ACCESS_NEW_RELATIONSHIP = "/metadata-manager/electronic_access-new_relationship.json";
 
   private static final String ITEM_BOTH_LOAN_TYPES = "/metadata-manager/item_both_loan_types.json";
   private static final String ITEM_ONLY_PERMANENT_LOAN_TYPE = "/metadata-manager/item_only_permanent_loan_type.json";
@@ -236,6 +237,7 @@ class RecordMetadataManagerTest {
     builder.add((Arguments.arguments(ITEM_WITH_ELECTRONIC_ACCESS_RELATED_RESOURCE, Arrays.asList("4", "2"))));
     builder.add((Arguments.arguments(ITEM_WITH_ELECTRONIC_ACCESS_RESOURCE, Arrays.asList("4", "0"))));
     builder.add((Arguments.arguments(ITEM_WITH_ELECTRONIC_ACCESS_VERSION_OF_RESOURCE, Arrays.asList("4", "1"))));
+    builder.add((Arguments.arguments(ITEM_WITH_ELECTRONIC_ACCESS_NEW_RELATIONSHIP, Arrays.asList("4", " "))));
     return builder.build();
   }
 

--- a/src/test/resources/metadata-manager/electronic_access-new_relationship.json
+++ b/src/test/resources/metadata-manager/electronic_access-new_relationship.json
@@ -1,0 +1,44 @@
+{
+  "instanceId": "2f7f23be-81a6-4227-85ba-7c1c81272ee1",
+  "updateddate": "2020-06-01T10:56:10.118Z",
+  "deleted": "false",
+  "itemsandholdingsfields": {
+    "items": [
+      {
+        "id": "13807cda-b618-4c37-8fe0-df03eed83b4f",
+        "volume": "Volume 1_2_1",
+        "location": {
+          "name" : "testName",
+          "location": {
+            "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+            "libraryId": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+            "campusName": "City Campus",
+            "libraryName": "Datalogisk Institut",
+            "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+            "institutionName": "Københavns Universitet"
+          }
+        },
+        "callNumber": {
+          "prefix": "prefix",
+          "suffix": "suffix",
+          "typeName": "512173a7-bd09-490e-b773-17d83f2b63fe",
+          "callNumber": "Call number 1_2_1"
+        },
+        "enumeration": "Enumeration 1_2_1",
+        "materialType": "book",
+        "barcode" : "testBarcode",
+        "chronology" : "testChronology",
+        "electronicAccess": [
+          {
+            "uri": "test.com",
+            "name": "New relationship",
+            "linkText": "GS demo Holding 1_2",
+            "publicNote": "URL public note",
+            "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+            "materialsSpecification": "Materials specified"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
[MODOAIPMH-473](https://issues.folio.org/browse/MODOAIPMH-473) - "856" field is omitted in responce for Electronic access relationship type created by user

## Purpose
 Electronic access relationship is driven by inventory settings, so users can edit (add, remove) any option.
In case user added a new Electronic access relationship and link it to a Holdings record then started to harvest the instance with such Holdings record, the "856" Holdings data field is not shown in the response

## Approach
Add possibility to return default value ("4, ") from map of indicators in case of new Electronic access relationship.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
