### PR TITLE
MODOAIPMH-433: Unable to build on ARM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -720,9 +720,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.gitlab.janecekpetr</groupId>
+        <groupId>com.github.slavaz</groupId>
         <artifactId>embedded-postgresql-maven-plugin</artifactId>
-        <version>0.1.0</version>
+        <version>1.2.4</version>
         <configuration>
           <pgServerPort>15432</pgServerPort>
           <dbName>postgres</dbName>

--- a/pom.xml
+++ b/pom.xml
@@ -759,7 +759,7 @@
         <configuration>
           <changeLogFile>src/main/resources/liquibase/tenant/changelog.xml</changeLogFile>
           <driver>org.postgresql.Driver</driver>
-          <url>jdbc:postgresql://localhost:15432/postgres</url>
+          <url>jdbc:postgresql://${pg.ip}:${pg.port}/postgres</url>
           <username>postgres</username>
           <password>postgres</password>
         </configuration>
@@ -814,7 +814,7 @@
         <configuration>
           <jdbc>
             <driver>org.postgresql.Driver</driver>
-            <url>jdbc:postgresql://localhost:15432/postgres</url>
+            <url>jdbc:postgresql://${pg.ip}:${pg.port}/postgres</url>
             <user>postgres</user>
             <password>postgres</password>
           </jdbc>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,11 @@
       <artifactId>caffeine</artifactId>
       <version>3.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.opentable.components</groupId>
+      <artifactId>otj-pg-embedded</artifactId>
+      <version>1.0.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -720,9 +725,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.github.slavaz</groupId>
+        <groupId>com.gitlab.janecekpetr</groupId>
         <artifactId>embedded-postgresql-maven-plugin</artifactId>
-        <version>1.2.4</version>
+        <version>0.1.0</version>
         <configuration>
           <pgServerPort>15432</pgServerPort>
           <dbName>postgres</dbName>


### PR DESCRIPTION
https://issues.folio.org/browse/MODOAIPMH-433

This uses https://github.com/slavaz/embedded-postgresql-maven-plugin. **It resolves the issue of a non-ARM binary not being found for Postgres.**

But as of now the build fails for me locally with a `liquibase.exception.DatabaseException: org.postgresql.util.PSQLException: Connection to localhost:15432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections` error which may just be with my local PG setup.