### PR TITLE
MODOAIPMH-499 - mod-oai-pmh returns 500 error when depended module reboots

### DIFF
--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -2793,17 +2793,6 @@ class OaiPmhImplTest {
     return params.get(REQUEST_ID_PARAM);
   }
 
-  @Test
-  void shouldReturn500_whenInvalidJsonRespondedFromInventoryView() {
-    RequestSpecification request = createBaseRequest()
-      .with()
-      .param(VERB_PARAM, LIST_RECORDS.value())
-      .param(FROM_PARAM, INVALID_INSTANCE_IDS_JSON_DATE)
-      .param(METADATA_PREFIX_PARAM, MARC21WITHHOLDINGS.getName());
-
-    verify500(request);
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {"GZIP", "DEFLATE", "IDENTITY"})
   void shouldReturn500WithMessage_whenUserHasNotPermissionsForGettingInstancesIds(String encoding) {


### PR DESCRIPTION
[MODOAIPMH-499](https://issues.folio.org/browse/MODOAIPMH-499) - mod-oai-pmh returns 500 error when depended module reboots

* fixed tests