### PR TITLE
MODOAIPMH-545 - Missing columns in request_metadata_lb in Poppy upgraded environments

### DIFF
--- a/src/main/resources/liquibase/tenant/scripts/2023-06-13--12-00-update-metadata-add-started-date.xml
+++ b/src/main/resources/liquibase/tenant/scripts/2023-06-13--12-00-update-metadata-add-started-date.xml
@@ -4,7 +4,8 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-  <changeSet id="2023-06-13--12-00-update-metadata-add-started-date" author="Oleksandr Bozhko">
+  <changeSet id="2023-06-13--12-00-update-metadata-add-started-date" author="Oleksandr Bozhko" runOnChange="true">
+    <delete tableName="request_metadata_lb"/>
     <addColumn tableName="request_metadata_lb">
       <column name="started_date" type="timestamptz">
         <constraints nullable="false"/>


### PR DESCRIPTION
[MODOAIPMH-545](https://issues.folio.org/browse/MODOAIPMH-545) - Missing columns in request_metadata_lb in Poppy upgraded environments

## Purpose
When upgrading from Orchid to Poppy, we are missing two columns for the table request_metadata_lb. Columns path_to_error_file_in_s3 and started_date are missing. We've seen this in multiple environments now.

## Approach
Updated liquibase migration to clear data in request_metadata_lb table

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
