### PR TITLE
MODOAIPMH-587 - Include FOLIO location in addition to Discovery Display Name

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -172,7 +172,7 @@
     },
     {
       "id": "inventory-hierarchy",
-      "version": "0.5"
+      "version": "0.6"
     },
     {
       "id": "source-storage-records",

--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -322,18 +322,24 @@ public class RecordMetadataManager {
     addSubFieldGroup(effectiveLocationSubFields, callNumberGroup, EffectiveLocationSubFields.getCallNumberValues());
     addSubFieldGroup(effectiveLocationSubFields, itemData, EffectiveLocationSubFields.getSimpleValues());
     updateSubfieldsMapWithItemLoanTypeSubfield(effectiveLocationSubFields, itemData);
-    // Map location discovery display name (or location name if null) to 952$d
+    addLocationDiscoveryDisplayNameOrLocationNameSubfield(itemData, effectiveLocationSubFields);
+    addLocationNameSubfield(itemData, effectiveLocationSubFields);
+    return effectiveLocationSubFields;
+  }
+
+  private void addLocationDiscoveryDisplayNameOrLocationNameSubfield(JsonObject itemData, Map<String, Object> effectiveLocationSubFields) {
     ofNullable(itemData.getJsonObject(LOCATION))
       .map(jo -> jo.getString(NAME))
       .filter(StringUtils::isNotBlank)
       .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_DISCOVERY_DISPLAY_NAME_OR_LOCATION_NAME_SUBFIELD_CODE, value));
-    // Map location name to 952$s
+  }
+
+  private void addLocationNameSubfield(JsonObject itemData, Map<String, Object> effectiveLocationSubFields) {
     ofNullable(itemData.getJsonObject(LOCATION))
       .map(jo -> jo.getJsonObject(LOCATION))
       .map(jo -> jo.getString(LOCATION_NAME))
       .filter(StringUtils::isNotBlank)
       .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_NAME_SUBFIELD_CODE, value));
-    return effectiveLocationSubFields;
   }
 
   private void updateSubfieldsMapWithItemLoanTypeSubfield(Map<String, Object> subFields, JsonObject itemData) {

--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -43,9 +43,10 @@ public class RecordMetadataManager {
 
   private static final String INDICATOR_VALUE = "f";
   private static final String DISCOVERY_SUPPRESSED_SUBFIELD_CODE = "t";
-  private static final String LOCATION_NAME_SUBFIELD_CODE = "d";
+  private static final String LOCATION_DISCOVERY_DISPLAY_NAME_OR_LOCATION_NAME_SUBFIELD_CODE = "d";
   private static final String LOAN_TYPE_SUBFIELD_CODE = "p";
   private static final String ILL_POLICY_SUBFIELD_CODE = "r";
+  private static final String LOCATION_NAME_SUBFIELD_CODE = "s";
 
   private static final int FIRST_INDICATOR_INDEX = 0;
   private static final int SECOND_INDICATOR_INDEX = 1;
@@ -70,6 +71,7 @@ public class RecordMetadataManager {
   public static final String CALL_NUMBER = "callNumber";
   public static final String ELECTRONIC_ACCESS = "electronicAccess";
   public static final String NAME = "name";
+  public static final String LOCATION_NAME = "locationName";
   public static final String SUPPRESS_DISCOVERY_CODE = "t";
 
   private RecordMetadataManager() {
@@ -320,9 +322,14 @@ public class RecordMetadataManager {
     addSubFieldGroup(effectiveLocationSubFields, callNumberGroup, EffectiveLocationSubFields.getCallNumberValues());
     addSubFieldGroup(effectiveLocationSubFields, itemData, EffectiveLocationSubFields.getSimpleValues());
     updateSubfieldsMapWithItemLoanTypeSubfield(effectiveLocationSubFields, itemData);
-    //Map location name, which changed paths in json, to 952$d
+    // Map location discovery display name (or location name if null) to 952$d
     ofNullable(itemData.getJsonObject(LOCATION))
       .map(jo -> jo.getString(NAME))
+      .filter(StringUtils::isNotBlank)
+      .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_DISCOVERY_DISPLAY_NAME_OR_LOCATION_NAME_SUBFIELD_CODE, value));
+    // Map location name to 952$s
+    ofNullable(itemData.getJsonObject(LOCATION))
+      .map(jo -> jo.getString(LOCATION_NAME))
       .filter(StringUtils::isNotBlank)
       .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_NAME_SUBFIELD_CODE, value));
     return effectiveLocationSubFields;

--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -329,6 +329,7 @@ public class RecordMetadataManager {
       .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_DISCOVERY_DISPLAY_NAME_OR_LOCATION_NAME_SUBFIELD_CODE, value));
     // Map location name to 952$s
     ofNullable(itemData.getJsonObject(LOCATION))
+      .map(jo -> jo.getJsonObject(LOCATION))
       .map(jo -> jo.getString(LOCATION_NAME))
       .filter(StringUtils::isNotBlank)
       .ifPresent(value -> effectiveLocationSubFields.put(LOCATION_NAME_SUBFIELD_CODE, value));

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -328,11 +328,13 @@ class RecordMetadataManagerTest {
       assertTrue(verifySubFieldValuePresence(subFieldsList, "b", "City Campus", true));
       assertTrue(verifySubFieldValuePresence(subFieldsList, "c", "Datalogisk Institut", true));
       assertTrue(verifySubFieldValuePresence(subFieldsList, "d", "testName", true));
+      assertTrue(verifySubFieldValuePresence(subFieldsList, "s", "testName", true));
     } else {
       assertFalse(verifySubFieldValuePresence(subFieldsList, "a", "Københavns Universitet", true));
       assertFalse(verifySubFieldValuePresence(subFieldsList, "b", "City Campus", true));
       assertFalse(verifySubFieldValuePresence(subFieldsList, "c", "Datalogisk Institut", true));
       assertFalse(verifySubFieldValuePresence(subFieldsList, "d", "testName", true));
+      assertFalse(verifySubFieldValuePresence(subFieldsList, "s", "testName", true));
     }
     if (callNumberGroupMustBePresented) {
       assertTrue(verifySubFieldValuePresence(subFieldsList, "e", "Call number 1_2_1", true));

--- a/src/test/resources/metadata-manager/inventory_instance_with_1_item.json
+++ b/src/test/resources/metadata-manager/inventory_instance_with_1_item.json
@@ -16,7 +16,8 @@
             "campusName": "City Campus",
             "libraryName": "Datalogisk Institut",
             "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
-            "institutionName": "Københavns Universitet"
+            "institutionName": "Københavns Universitet",
+            "locationName": "testName"
           }
         },
         "callNumber": {

--- a/src/test/resources/metadata-manager/inventory_instance_with_2_items.json
+++ b/src/test/resources/metadata-manager/inventory_instance_with_2_items.json
@@ -15,7 +15,8 @@
             "campusName": "City Campus",
             "libraryName": "Datalogisk Institut",
             "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
-            "institutionName": "Københavns Universitet"
+            "institutionName": "Københavns Universitet",
+            "locationName": "testName"
           }
         },
         "callNumber": {
@@ -51,7 +52,8 @@
             "campusName": "City Campus",
             "libraryName": "Datalogisk Institut",
             "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
-            "institutionName": "Københavns Universitet"
+            "institutionName": "Københavns Universitet",
+            "locationName": "testName"
           }
         },
         "callNumber": {

--- a/src/test/resources/metadata-manager/inventory_instance_with_item_without_call_number.json
+++ b/src/test/resources/metadata-manager/inventory_instance_with_item_without_call_number.json
@@ -16,7 +16,8 @@
             "campusName": "City Campus",
             "libraryName": "Datalogisk Institut",
             "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
-            "institutionName": "Københavns Universitet"
+            "institutionName": "Københavns Universitet",
+            "locationName": "testName"
           }
         },
         "enumeration": "Enumeration 1_2_1",


### PR DESCRIPTION
[MODOAIPMH-587](https://folio-org.atlassian.net/browse/MODOAIPMH-587) - Include FOLIO location in addition to Discovery Display Name

## Purpose
FOLIO's OAI-PMH implementation populates location data as specified in   based on Discovery display name.  However, some libraries would prefer to have FOLIO location to be included in the response as well.

## Approach
Update view in mod-inventory-storage and add locationName field, retrieve locationName and populate 952 $s.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
