### PR TITLE
MODOAIPMH-581 - Harvesting instances with LINKED_DATA source

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
+++ b/src/main/java/org/folio/oaipmh/helpers/AbstractGetRecordsHelper.java
@@ -430,6 +430,10 @@ public abstract class AbstractGetRecordsHelper extends AbstractHelper {
       && request.getVerb() != VerbType.LIST_IDENTIFIERS) {
         generateRecordsOnTheFly(request, inventoryRecords);
       }
+      // Exclude inventory instance if srs is present.
+      if (request.getVerb() == VerbType.GET_RECORD && !srsRecords.getJsonArray(SOURCE_RECORDS_PARAM).isEmpty()) {
+        inventoryRecords = null;
+      }
       processRecords(ctx, request, srsRecords, inventoryRecords)
         .onComplete(oaiResponse -> promise.complete(oaiResponse.result()));
     } else {

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -611,6 +611,29 @@ class OaiPmhImplTest {
   }
 
   @Test
+  void getOaiRecordWhenSourceIsLinkedDataAndNeedToExcludeInventoryRecordIfSrsIsPresent() {
+    System.setProperty(REPOSITORY_RECORDS_SOURCE, SRS_AND_INVENTORY);
+    var maxRecords = System.getProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE);
+    System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, "50");
+
+    RequestSpecification request = createBaseRequest()
+      .with()
+      .param(VERB_PARAM, GET_RECORD.value())
+      .param(IDENTIFIER_PARAM, IDENTIFIER_PREFIX + "linked-data-identifier")
+      .param(METADATA_PREFIX_PARAM, MARC21XML.getName());
+
+    OAIPMH oaiPmhResponseWithExistingIdentifier = verify200WithXml(request, GET_RECORD);
+    HeaderType recordHeader = oaiPmhResponseWithExistingIdentifier.getGetRecord().getRecord().getHeader();
+    verifyIdentifiers(Collections.singletonList(recordHeader),
+      Collections.singletonList("linked-data-identifier"));
+    assertThat(oaiPmhResponseWithExistingIdentifier.getGetRecord(), is(notNullValue()));
+    assertThat(oaiPmhResponseWithExistingIdentifier.getErrors(), is(empty()));
+
+    System.setProperty(REPOSITORY_RECORDS_SOURCE, SRS);
+    System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, maxRecords);
+  }
+
+  @Test
   void shouldBuildListRecordsIfOneInstanceReturn500FromInventoryItemsAndHoldingsEndpoint() {
     RequestSpecification request = createBaseRequest()
       .with()

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -199,6 +199,8 @@ public class OkapiMockServer {
   private static final String INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS = "instance.json";
   private static final String ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS = "enriched_instance.json";
   private static final String ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS_INVALID_DATA = "enriched_instance_invalid_data.json";
+  private static final String INSTANCE_LINKED_DATA = "/instance_linked_data.json";
+  private static final String SRS_RECORD_LINKED_DATA = "/linked_data_srs_record.json";
 
   private static final String INSTANCE_ID_UNDERLYING_RECORD_WITH_CYRILLIC_DATA = "ebbb759a-dd08-4bf8-b3c3-3d75b2190c41";
   private static final String INSTANCE_ID_WITHOUT_SRS_RECORD = "3a6a47ab-597d-4abe-916d-e31c723426d3";
@@ -209,6 +211,7 @@ public class OkapiMockServer {
   private static final String INSTANCE_ID_GET_RECORD_MARC21_WITH_HOLDINGS_FROM_INVENTORY = "00000000-0000-4000-a000-000000000111";
   private static final String INSTANCE_ID_GET_RECORD_MARC21_WITH_HOLDINGS_FROM_INVENTORY_INVALID_DATA = "12345000-0000-4000-a000-000000000111";
   private static final String INSTANCES_FROM_INVENTORY_WITH_SOURCE_FOLIO = "FOLIO";
+  private static final String INSTANCE_ID_WITH_LINKED_DATA = "linked-data-identifier";
 
 
   private static final String JSON_TEMPLATE_KEY_RECORDS = "replace_with_records";
@@ -407,6 +410,8 @@ public class OkapiMockServer {
       successResponse(ctx, getJsonObjectFromFileAsString(INVENTORY_VIEW_PATH + ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS));
     } else if (uri.contains(INSTANCE_ID_GET_RECORD_MARC21_WITH_HOLDINGS_FROM_INVENTORY_INVALID_DATA)) {
       successResponse(ctx, getJsonObjectFromFileAsString(INVENTORY_VIEW_PATH + ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS_INVALID_DATA));
+    } else if (uri.contains(INSTANCE_ID_WITH_LINKED_DATA)) {
+      successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_STORAGE_URI + INSTANCE_LINKED_DATA));
     } else  if (uri.contains(INSTANCES_FROM_INVENTORY_WITH_SOURCE_FOLIO)) {
       successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_STORAGE_URI + INSTANCES_WITH_SOURCE_FOLIO));
     } else if (uri.contains(DATE_FOR_INSTANCES_10_PARTIALLY)) {
@@ -469,6 +474,8 @@ public class OkapiMockServer {
     if (uri != null) {
       if (uri.contains(DEFAULT_RECORD_DATE)) {
         successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
+      } else if (uri.contains(INSTANCE_ID_WITH_LINKED_DATA)) {
+        successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_LINKED_DATA));
       } else if (uri.contains(String.format("%s=%s", ID_PARAM, EXISTING_IDENTIFIER))
           || uri.contains(String.format("%s=%s", ID_PARAM, RECORD_IDENTIFIER_MARC21_WITH_HOLDINGS))) {
         successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_1));

--- a/src/test/java/org/folio/rest/impl/OkapiMockServer.java
+++ b/src/test/java/org/folio/rest/impl/OkapiMockServer.java
@@ -200,6 +200,7 @@ public class OkapiMockServer {
   private static final String ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS = "enriched_instance.json";
   private static final String ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS_INVALID_DATA = "enriched_instance_invalid_data.json";
   private static final String INSTANCE_LINKED_DATA = "/instance_linked_data.json";
+  private static final String INSTANCE_NO_SRS_DATA = "/instances_no_srs.json";
   private static final String SRS_RECORD_LINKED_DATA = "/linked_data_srs_record.json";
 
   private static final String INSTANCE_ID_UNDERLYING_RECORD_WITH_CYRILLIC_DATA = "ebbb759a-dd08-4bf8-b3c3-3d75b2190c41";
@@ -212,6 +213,7 @@ public class OkapiMockServer {
   private static final String INSTANCE_ID_GET_RECORD_MARC21_WITH_HOLDINGS_FROM_INVENTORY_INVALID_DATA = "12345000-0000-4000-a000-000000000111";
   private static final String INSTANCES_FROM_INVENTORY_WITH_SOURCE_FOLIO = "FOLIO";
   private static final String INSTANCE_ID_WITH_LINKED_DATA = "linked-data-identifier";
+  private static final String INSTANCE_NO_SRS = "no-srs-identifier";
 
 
   private static final String JSON_TEMPLATE_KEY_RECORDS = "replace_with_records";
@@ -412,6 +414,8 @@ public class OkapiMockServer {
       successResponse(ctx, getJsonObjectFromFileAsString(INVENTORY_VIEW_PATH + ENRICHED_INSTANCE_JSON_GET_RECORD_MARC21_WITH_HOLDINGS_INVALID_DATA));
     } else if (uri.contains(INSTANCE_ID_WITH_LINKED_DATA)) {
       successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_STORAGE_URI + INSTANCE_LINKED_DATA));
+    } else if (uri.contains(INSTANCE_NO_SRS)) {
+      successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_STORAGE_URI + INSTANCE_NO_SRS_DATA));
     } else  if (uri.contains(INSTANCES_FROM_INVENTORY_WITH_SOURCE_FOLIO)) {
       successResponse(ctx, getJsonObjectFromFileAsString(INSTANCE_STORAGE_URI + INSTANCES_WITH_SOURCE_FOLIO));
     } else if (uri.contains(DATE_FOR_INSTANCES_10_PARTIALLY)) {
@@ -476,6 +480,8 @@ public class OkapiMockServer {
         successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + DEFAULT_SRS_RECORD));
       } else if (uri.contains(INSTANCE_ID_WITH_LINKED_DATA)) {
         successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + SRS_RECORD_LINKED_DATA));
+      } else if (uri.contains(INSTANCE_NO_SRS)) {
+        successResponse(ctx, "{\"sourceRecords\": [],\"totalRecords\": 0}");
       } else if (uri.contains(String.format("%s=%s", ID_PARAM, EXISTING_IDENTIFIER))
           || uri.contains(String.format("%s=%s", ID_PARAM, RECORD_IDENTIFIER_MARC21_WITH_HOLDINGS))) {
         successResponse(ctx, getJsonObjectFromFileAsString(SOURCE_STORAGE_RESULT_URI + INSTANCES_1));

--- a/src/test/resources/instance-storage/instances/instance_linked_data.json
+++ b/src/test/resources/instance-storage/instances/instance_linked_data.json
@@ -1,0 +1,44 @@
+{
+  "id": "linked-data-identifier",
+  "hrid": "in000001",
+  "source": "LINKED_DATA",
+  "title": "ABA Journal",
+  "alternativeTitles": [],
+  "series": [],
+  "identifiers": [
+    {
+      "value": "0747-0088",
+      "identifierTypeId": "913300b2-03ed-469a-8179-c1092c991227"
+    },
+    {
+      "value": "84641839",
+      "identifierTypeId": "c858e4f2-2b6b-4385-842b-60732ee14abb"
+    }
+  ],
+  "contributors": [],
+  "subjects": [],
+  "classifications": [],
+  "publication": [
+    {
+      "publisher": "American Bar Association",
+      "place": "Chicago, Ill.",
+      "dateOfPublication": "1915-1983"
+    }
+  ],
+  "publicationFrequency": [],
+  "publicationRange": [],
+  "urls": [],
+  "electronicAccess": [],
+  "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+  "physicalDescriptions": [],
+  "languages": [],
+  "notes": [],
+  "statisticalCodes": [],
+  "discoverySuppress": false,
+  "metadata": {
+    "createdDate": "2018-09-19T02:52:22.096+0000",
+    "createdByUserId": "50b42bbf-7071-5106-95d6-1d25bf7324ff",
+    "updateddate": "2018-09-19T02:52:22.096+0000",
+    "updatedByUserId": "50b42bbf-7071-5106-95d6-1d25bf7324ff"
+  }
+}

--- a/src/test/resources/instance-storage/instances/instances_no_srs.json
+++ b/src/test/resources/instance-storage/instances/instances_no_srs.json
@@ -1,9 +1,9 @@
 {
   "instances": [
     {
-      "id": "linked-data-identifier",
+      "id": "no-srs-identifier",
       "hrid": "in000001",
-      "source": "LINKED_DATA",
+      "source": "FOLIO",
       "title": "ABA Journal",
       "alternativeTitles": [],
       "series": [],

--- a/src/test/resources/source-storage/source-records/linked_data_srs_record.json
+++ b/src/test/resources/source-storage/source-records/linked_data_srs_record.json
@@ -1,0 +1,351 @@
+{
+  "sourceRecords": [
+    {
+      "recordId": "22085e3b-8b42-46f1-9820-0c52cc3201e1",
+      "snapshotId": "dcca0c83-f338-4434-8770-e33dc31629b8",
+      "recordType": "MARC",
+      "parsedRecord": {
+        "id": "e5eef701-8880-47eb-a7c3-8b2dddd1ebe3",
+        "content": {
+          "leader": "01344nja a2200289 c 4500",
+          "fields": [
+            {
+              "001": "1011162431"
+            },
+            {
+              "003": "DE-601"
+            },
+            {
+              "005": "20180118183625.0"
+            },
+            {
+              "007": "su uuuuuuuuuuu"
+            },
+            {
+              "008": "180118s2017                  000 0 ger d"
+            },
+            {
+              "035": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "(DE-599)GBV1011162431"
+                  }
+                ]
+              }
+            },
+            {
+              "040": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "b": "ger"
+                  },
+                  {
+                    "c": "GBVCP"
+                  },
+                  {
+                    "e": "rda"
+                  }
+                ]
+              }
+            },
+            {
+              "041": {
+                "ind1": "0",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "ger"
+                  }
+                ]
+              }
+            },
+            {
+              "100": {
+                "ind1": "1",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Bach, Johann Sebastian"
+                  },
+                  {
+                    "e": "KomponistIn"
+                  },
+                  {
+                    "4": "cmp"
+                  },
+                  {
+                    "0": "(DE-601)134579348"
+                  },
+                  {
+                    "0": "(DE-588)11850553X"
+                  }
+                ]
+              }
+            },
+            {
+              "240": {
+                "ind1": "1",
+                "ind2": "0",
+                "subfields": [
+                  {
+                    "0": "(DE-601)701589477"
+                  },
+                  {
+                    "0": "(DE-588)300007736"
+                  },
+                  {
+                    "a": "Ich habe genung"
+                  }
+                ]
+              }
+            },
+            {
+              "245": {
+                "ind1": "1",
+                "ind2": "0",
+                "subfields": [
+                  {
+                    "a": "Cantatas for bass"
+                  },
+                  {
+                    "n": "4"
+                  },
+                  {
+                    "p": "Ich habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor"
+                  }
+                ]
+              }
+            },
+            {
+              "246": {
+                "ind1": "1",
+                "ind2": "3",
+                "subfields": [
+                  {
+                    "i": "Abweichender Titel"
+                  },
+                  {
+                    "a": "Ich habe genung"
+                  }
+                ]
+              }
+            },
+            {
+              "300": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Track 10-14"
+                  }
+                ]
+              }
+            },
+            {
+              "336": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "aufgeführte Musik"
+                  },
+                  {
+                    "b": "prm"
+                  },
+                  {
+                    "2": "rdacontent"
+                  }
+                ]
+              }
+            },
+            {
+              "337": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "audio"
+                  },
+                  {
+                    "b": "s"
+                  },
+                  {
+                    "2": "rdamedia"
+                  }
+                ]
+              }
+            },
+            {
+              "338": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Audiodisk"
+                  },
+                  {
+                    "b": "sd"
+                  },
+                  {
+                    "2": "rdacarrier"
+                  }
+                ]
+              }
+            },
+            {
+              "700": {
+                "ind1": "1",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Arfken, Katharina"
+                  },
+                  {
+                    "e": "InstrumentalmusikerIn"
+                  },
+                  {
+                    "4": "itr"
+                  },
+                  {
+                    "0": "(DE-601)576364940"
+                  },
+                  {
+                    "0": "(DE-588)135158265"
+                  }
+                ]
+              }
+            },
+            {
+              "700": {
+                "ind1": "1",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Goltz, Gottfried von der"
+                  },
+                  {
+                    "e": "DirigentIn"
+                  },
+                  {
+                    "4": "cnd"
+                  },
+                  {
+                    "0": "(DE-601)081724969"
+                  },
+                  {
+                    "0": "(DE-588)122080912"
+                  }
+                ]
+              }
+            },
+            {
+              "710": {
+                "ind1": "2",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "Freiburger Barockorchester"
+                  },
+                  {
+                    "e": "InstrumentalmusikerIn"
+                  },
+                  {
+                    "4": "itr"
+                  },
+                  {
+                    "0": "(DE-601)12121060X"
+                  },
+                  {
+                    "0": "(DE-588)5066798-1"
+                  }
+                ]
+              }
+            },
+            {
+              "773": {
+                "ind1": "0",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "w": "(DE-601)895161729"
+                  },
+                  {
+                    "t": "Cantatas for bass, Bach, Johann Sebastian. - Arles : Harmonia Mundi"
+                  }
+                ]
+              }
+            },
+            {
+              "900": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "a": "GBV"
+                  },
+                  {
+                    "b": "SBB-PK Berlin <1+1A>"
+                  }
+                ]
+              }
+            },
+            {
+              "954": {
+                "ind1": " ",
+                "ind2": " ",
+                "subfields": [
+                  {
+                    "0": "SBB-PK Berlin <1+1A>"
+                  },
+                  {
+                    "a": "11"
+                  },
+                  {
+                    "b": "1742288871"
+                  },
+                  {
+                    "c": "01"
+                  },
+                  {
+                    "x": "0001"
+                  }
+                ]
+              }
+            },
+            {
+              "999": {
+                "ind1": "f",
+                "ind2": "f",
+                "subfields": [
+                  {
+                    "s": "22085e3b-8b42-46f1-9820-0c52cc3201e1"
+                  },
+                  {
+                    "i": "linked-data-identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "externalIdsHolder": {
+        "instanceId": "linked-data-identifier"
+      },
+      "additionalInfo": {
+        "suppressDiscovery": false
+      },
+      "metadata": {
+        "createdDate": "2018-11-20T07:23:11.172+0000",
+        "createdByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092",
+        "updatedDate": "2018-11-20T07:23:11.172+0000",
+        "updatedByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092"
+      }
+    }
+  ],
+  "totalRecords": 1
+}


### PR DESCRIPTION
[MODOAIPMH-581](https://folio-org.atlassian.net/browse/MODOAIPMH-581) - Harvesting instances with LINKED_DATA source

## Purpose
Exclude inventory data if srs is present for GetRecord.

## Approach

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
