### PR TITLE
MODOAIPMH-611: Update dependencies for Sunflower fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency> <!-- needed for mockserver-client-java -->
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
@@ -143,37 +136,35 @@
     <!-- Plugin versions -->
     <aspectj.version>1.9.21.1</aspectj.version>
     <raml-module-builder.version>35.4.0</raml-module-builder.version>
-    <folio-liquibase-util.version>1.7.0</folio-liquibase-util.version>
-    <data-import-utils.version>1.10.0</data-import-utils.version>
-    <folio-di-support.version>2.1.0</folio-di-support.version>
-    <vertx.version>4.5.4</vertx.version>
-    <apache-httpclient.version>4.5.13</apache-httpclient.version>
+    <folio-liquibase-util.version>1.10.0</folio-liquibase-util.version>
+    <data-import-utils.version>1.14.0</data-import-utils.version>
+    <folio-di-support.version>3.0.0</folio-di-support.version>
+    <vertx.version>4.5.14</vertx.version>
+    <apache-httpclient.version>4.5.14</apache-httpclient.version>
     <time-adapters.version>1.1.3</time-adapters.version>
     <jaxb2-basics.version>1.11.1</jaxb2-basics.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <jaxb-impl.version>2.3.4</jaxb-impl.version>
     <jaxb-osgi.version>4.0.3</jaxb-osgi.version>
     <marc4j.version>2.9.6</marc4j.version>
-    <mod-configuration-client.version>5.9.2</mod-configuration-client.version>
-    <mod-source-record-storage-client.version>5.4.0</mod-source-record-storage-client.version>
-    <restassured.version>5.4.0</restassured.version>
-    <junit.jupiter.version>5.9.0-M1</junit.jupiter.version>
-    <jooq.version>3.19.6</jooq.version>
-    <vertx-jooq.generator.version>6.5.4</vertx-jooq.generator.version>
-    <vertx-jooq.classic-reactive.version>6.5.4</vertx-jooq.classic-reactive.version>
-    <postgres.version>42.7.2</postgres.version>
-    <lombok.version>1.18.36</lombok.version>
-    <log4j.version>2.23.1</log4j.version>
-    <testcontainers.version>1.19.7</testcontainers.version>
-    <mockito-junit-jupiter.version>5.2.0</mockito-junit-jupiter.version>
-    <junit.version>5.10.2</junit.version>
-    <netty.version>4.1.107.Final</netty.version>
+    <mod-configuration-client.version>5.12.0</mod-configuration-client.version>
+    <mod-source-record-storage-client.version>5.10.1</mod-source-record-storage-client.version>
+    <restassured.version>5.5.1</restassured.version>
+    <jooq.version>3.20.3</jooq.version>
+    <vertx-jooq.generator.version>6.5.5</vertx-jooq.generator.version>
+    <vertx-jooq.classic-reactive.version>6.5.5</vertx-jooq.classic-reactive.version>
+    <postgres.version>42.7.5</postgres.version>
+    <lombok.version>1.18.38</lombok.version>
+    <log4j.version>2.24.3</log4j.version>
+    <testcontainers.version>1.20.6</testcontainers.version>
+    <mockito-junit-jupiter.version>5.17.0</mockito-junit-jupiter.version>
+    <junit.version>5.12.2</junit.version>
     <mockserver-client-java.version>5.15.0</mockserver-client-java.version>
     <generate-marc-utils-version>1.10.0</generate-marc-utils-version>
-    <postgres.image>postgres:12-alpine</postgres.image>
+    <postgres.image>postgres:16-alpine</postgres.image>
     <folio-s3-client.version>2.3.0</folio-s3-client.version>
-    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
-    <aws.sdk.version>2.29.9</aws.sdk.version>
+    <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
+    <aws.sdk.version>2.31.21</aws.sdk.version>
     <json-smart.version>2.5.2</json-smart.version>
 
   </properties>

--- a/src/main/java/org/folio/oaipmh/processors/GetListRecordsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/GetListRecordsRequestHelper.java
@@ -287,49 +287,47 @@ public class GetListRecordsRequestHelper extends AbstractGetRecordsHelper {
                                AtomicInteger attemptsCount, int retryAttempts, Promise<JsonArray> promise,
                                Request request, JsonArray records) {
     logger.info("doRequestShared execution");
-    try (var client = SourceStorageSourceRecordsClientWrapper.getSourceStorageSourceRecordsClient(request)) {
-      client.postSourceStorageSourceRecords("INSTANCE",
-        null, deletedRecordsSupport, new ArrayList<>(idJsonMap.keySet()), asyncResult -> {
-          Map<String, String> retrySRSRequestParams = new HashMap<>();
-          if (asyncResult.succeeded()) {
-            HttpResponse<Buffer> srsResponse = asyncResult.result();
-            int statusCode = srsResponse.statusCode();
-            String statusMessage = srsResponse.statusMessage();
-            if (statusCode >= 400) {
-              retrySRSRequestParams.put(RETRY_ATTEMPTS, String.valueOf(retryAttempts));
-              retrySRSRequestParams.put(STATUS_CODE, String.valueOf(statusCode));
-              retrySRSRequestParams.put(STATUS_MESSAGE, statusMessage);
-              retrySRSRequest(vertx, deletedRecordsSupport, idJsonMap, attemptsCount, promise, retrySRSRequestParams,
-                request, records);
-            }
-            if (statusCode != 200) {
-              String errorMsg = getErrorFromStorageMessage("source-record-storage", "/source-storage/source-records",
-                srsResponse.statusMessage());
-              handleException(promise, new IllegalStateException(errorMsg));
-              logger.error("Error response: {}", srsResponse.bodyAsString());
-            }
-            JsonArray sourceRecords = srsResponse.bodyAsJsonObject().getJsonArray("sourceRecords");
-            sourceRecords.stream().map(JsonObject.class::cast)
-              .forEach(json -> {
-                var instId = json.getJsonObject("externalIdsHolder").getString("instanceId");
-                var parsedRecord = json.getJsonObject(PARSED_RECORD);
-                var existingRecord = idJsonMap.get(instId);
-                existingRecord.put(PARSED_RECORD, parsedRecord);
-              });
-            promise.complete(new JsonArray(new ArrayList<>(idJsonMap.values())));
-          } else {
-            logger.error("Error has been occurred while requesting the SRS: {}.", asyncResult.cause()
-              .getMessage(), asyncResult.cause());
+    var client = SourceStorageSourceRecordsClientWrapper.getSourceStorageSourceRecordsClient(request);
+    client.postSourceStorageSourceRecords("INSTANCE",
+      null, deletedRecordsSupport, new ArrayList<>(idJsonMap.keySet()), asyncResult -> {
+        client.close();
+        Map<String, String> retrySRSRequestParams = new HashMap<>();
+        if (asyncResult.succeeded()) {
+          HttpResponse<Buffer> srsResponse = asyncResult.result();
+          int statusCode = srsResponse.statusCode();
+          String statusMessage = srsResponse.statusMessage();
+          if (statusCode >= 400) {
             retrySRSRequestParams.put(RETRY_ATTEMPTS, String.valueOf(retryAttempts));
-            retrySRSRequestParams.put(STATUS_CODE, String.valueOf(-1));
-            retrySRSRequestParams.put(STATUS_MESSAGE, "");
+            retrySRSRequestParams.put(STATUS_CODE, String.valueOf(statusCode));
+            retrySRSRequestParams.put(STATUS_MESSAGE, statusMessage);
             retrySRSRequest(vertx, deletedRecordsSupport, idJsonMap, attemptsCount, promise, retrySRSRequestParams,
               request, records);
           }
-        });
-    } catch (Exception e) {
-      promise.fail(e);
-    }
+          if (statusCode != 200) {
+            String errorMsg = getErrorFromStorageMessage("source-record-storage", "/source-storage/source-records",
+              srsResponse.statusMessage());
+            handleException(promise, new IllegalStateException(errorMsg));
+            logger.error("Error response: {}", srsResponse.bodyAsString());
+          }
+          JsonArray sourceRecords = srsResponse.bodyAsJsonObject().getJsonArray("sourceRecords");
+          sourceRecords.stream().map(JsonObject.class::cast)
+            .forEach(json -> {
+              var instId = json.getJsonObject("externalIdsHolder").getString("instanceId");
+              var parsedRecord = json.getJsonObject(PARSED_RECORD);
+              var existingRecord = idJsonMap.get(instId);
+              existingRecord.put(PARSED_RECORD, parsedRecord);
+            });
+          promise.complete(new JsonArray(new ArrayList<>(idJsonMap.values())));
+        } else {
+          logger.error("Error has been occurred while requesting the SRS: {}.", asyncResult.cause()
+            .getMessage(), asyncResult.cause());
+          retrySRSRequestParams.put(RETRY_ATTEMPTS, String.valueOf(retryAttempts));
+          retrySRSRequestParams.put(STATUS_CODE, String.valueOf(-1));
+          retrySRSRequestParams.put(STATUS_MESSAGE, "");
+          retrySRSRequest(vertx, deletedRecordsSupport, idJsonMap, attemptsCount, promise, retrySRSRequestParams,
+            request, records);
+        }
+      });
   }
 
   private void retrySRSRequest(Vertx vertx, boolean deletedRecordsSupport,

--- a/src/main/java/org/folio/oaipmh/service/SourceStorageSourceRecordsClientWrapper.java
+++ b/src/main/java/org/folio/oaipmh/service/SourceStorageSourceRecordsClientWrapper.java
@@ -53,7 +53,7 @@ public class SourceStorageSourceRecordsClientWrapper implements AutoCloseable {
     client
       .getSourceStorageSourceRecords(recordId, snapshotId, externalId, externalHrid, instanceId, instanceHrid, holdingsId,
           holdingsHrid, recordType, suppressFromDiscovery, deleted, leaderRecordStatus, updatedAfter, updatedBefore, orderBy,
-          offset, limit)
+          null, offset, limit)
       .onComplete(httpResponseAsyncResult -> {
         metricsCollectingService.endMetric(requestId, SRS_RESPONSE);
         responseHandler.handle(httpResponseAsyncResult);
@@ -61,7 +61,7 @@ public class SourceStorageSourceRecordsClientWrapper implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     webClient.close();
   }
 }

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -180,6 +180,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1843,7 +1844,7 @@ class OaiPmhImplTest {
   private void verifyBaseResponse(OAIPMH oaipmhFromString, VerbType verb) {
     assertThat(oaipmhFromString, is(notNullValue()));
     assertThat(oaipmhFromString.getResponseDate(), is(notNullValue()));
-    assertThat(oaipmhFromString.getResponseDate().isBefore(Instant.now()), is(true));
+    assertThat(oaipmhFromString.getResponseDate(), is(lessThanOrEqualTo(Instant.now())));
     assertThat(oaipmhFromString.getRequest(), is(notNullValue()));
     assertThat(oaipmhFromString.getRequest().getValue(), is(notNullValue()));
     assertThat(oaipmhFromString.getRequest().getVerb(), equalTo(verb));


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODOAIPMH-611

Update all dependencies to a supported version.

This fixes multiple security vulnerabilities:

* CVE-2025-24970 – https://github.com/advisories/GHSA-4g8c-wm8x-jfhw
* CVE-2025-25193 – https://github.com/netty/netty/security/advisories/GHSA-389x-839f-4rhx
* CVE-2024-29025 – https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v
* https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518
* CVE-2024-38820 – https://github.com/advisories/GHSA-4gc7-5j7h-4qph

Upgrade folio-liquibase-util from unsupported Poppy version 1.7.0 to Sunflower version 1.10.0.

Upgrade data-import-utils from unsupported Poppy version 1.10.0 to Sunflower version 1.14.0.

Upgrade folio-di-support from Quesnelia version 2.1.0 to Sunflower version 3.0.0.

Upgrade vertx from Quesnelia version 4.5.4 to Sunflower version 4.5.14.

Upgrade apache-httpclient from unsupported version 4.5.13 (released Oct 2020) to current version 4.5.14 (released Nov 2022).

Upgrade mod-configuration-client from unsupported Poppy version 5.9.2 to Sunflower version 5.12.0.

Upgrade mod-source-record-storage-client from Nolana version 5.4.0 to Sunflower version 5.10.1.

Upgrade jooq from unsupported version 3.19.6 to version 3.20.3, see Java 21 support: https://www.jooq.org/download/versions 

Upgrade vertx-jooq from unsupported version 6.5.4 (released Jun 2022) to latest version 6.5.5.

Upgrade postgres (client) from unsupported version 42.7.2 to latest version 42.7.5, see https://jdbc.postgresql.org/download/

Upgrade lombok from 1.18.36 to 1.18.38.

Upgrade log4j.version from 2.23.1 to 2.24.3. 

Upgrade aws.sdk from 2.29.9 to 2.31.21.

Also upgrade test dependencies.

Bug fix in AbstractGetRecordsHelper and GetListRecordsRequestHelper:

* Close the SourceStorageSourceRecordsClientWrapper asynchronously. Closing it synchronously may close it before it gets used because it gets used asynchronously; this actually happens with Vert.x since 4.5.5.

Update SourceStorageSourceRecordsClientWrapper:

* getSourceStorageSourceRecords uses latest RMB version that requires the additional totalRecords parameter; set it to null to use the default.

* Remove unused "throws Exception" from close().

Fix OaiPmhImplTest:

* Fix race condition by changing < Instant.now() to <= Instant.now().

## Purpose
Update dependencies for Sunflower fixing vulns. All dependencies should be at a supported versions.

## Approach
Bump the version in pom.xml, adjust the code accordingly.

## Learning
Don't release a module version without bumping all dependencies to a supported version.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.