### PR TITLE
MODOAIPMH-614 - Set for deletion FOLIO Instances are harvested with ListRecords, ListIdentifiers requests as not deleted

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "oai-pmh",
-      "version": "3.3",
+      "version": "3.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -4,6 +4,11 @@
       "run": "after",
       "snippetPath": "create_views.sql",
       "fromModuleVersion": "mod-oai-pmh-3.12.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "update_instance_deleted.sql",
+      "fromModuleVersion": "mod-oai-pmh-3.15.1"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/update_instance_deleted.sql
+++ b/src/main/resources/templates/db_scripts/update_instance_deleted.sql
@@ -1,0 +1,48 @@
+--DROP VIEW IF EXISTS ${myuniversity}_${mymodule}.get_instances_from_inventory CASCADE;
+--DROP VIEW IF EXISTS ${myuniversity}_${mymodule}.get_instances_from_inventory_deleted CASCADE;
+--DROP VIEW IF EXISTS ${myuniversity}_${mymodule}.get_instances_with_marc_records_deleted CASCADE;
+
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.get_instances_from_inventory AS
+SELECT * FROM ${myuniversity}_mod_inventory_storage.instance
+WHERE jsonb ->> 'deleted' = 'false';
+
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.get_instances_from_inventory_deleted AS
+SELECT * FROM ${myuniversity}_mod_inventory_storage.instance
+WHERE jsonb ->> 'deleted' = 'true';
+
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.get_instances_with_marc_records_deleted AS
+SELECT (jsonb ->> 'id')::uuid                                                                                              instance_id,
+      marc_record.content                                                                                                     marc_record,
+      instance_record.jsonb                                                                                                   instance_record,
+      instance_record.jsonb ->> 'source'                                                                                      source,
+      ${myuniversity}_mod_inventory_storage.strToTimestamp(record_lb.updated_date::text)             instance_updated_date,
+      ${myuniversity}_mod_inventory_storage.strToTimestamp(record_lb.created_date::text)             instance_created_date,
+      COALESCE(record_lb.suppress_discovery, false)                                                                           suppress_from_discovery_srs,
+      COALESCE((instance_record.jsonb ->> 'discoverySuppress')::bool, false)                                                  suppress_from_discovery_inventory,
+      true                                                                                                                    deleted
+      FROM ${myuniversity}_${mymodule}.get_instances_from_srs_deleted record_lb
+      INNER JOIN ${myuniversity}_${mymodule}.get_instances_from_inventory instance_record
+      ON instance_record.id = record_lb.external_id
+      INNER JOIN ${myuniversity}_${mymodule}.get_marc_records marc_record  ON marc_record.id = record_lb.id
+UNION ALL
+SELECT (jsonb -> 'record' ->> 'id')::uuid                                                                                     instance_id,
+      null                                                                                                                    marc_record,
+      instance_record.jsonb                                                                                                   instance_record,
+      instance_record.jsonb -> 'record' ->> 'source'                                                                          source,
+      ${myuniversity}_mod_inventory_storage.strToTimestamp(instance_record.jsonb ->> 'createdDate') instance_updated_date,
+      ${myuniversity}_mod_inventory_storage.strToTimestamp(instance_record.jsonb ->> 'createdDate') instance_created_date,
+      false                                                                                                                   suppress_from_discovery_srs,
+      COALESCE((instance_record.jsonb ->> 'discoverySuppress')::bool, false)                                                  suppress_from_discovery_inventory,
+      true                                                                                                                    deleted
+      FROM ${myuniversity}_${mymodule}.get_deleted_instances instance_record
+UNION ALL
+SELECT instance_record.id                                                                                                          instance_id,
+      null                                                                                                                         marc_record,
+      instance_record.jsonb                                                                                                        instance_record,
+      instance_record.jsonb ->> 'source'                                                                                           source,
+      instance_record.complete_updated_date AS                                                                                     instance_updated_date,
+      ${myuniversity}_mod_inventory_storage.strtotimestamp((instance_record.jsonb -> 'metadata'::text) ->> 'createdDate'::text) AS instance_created_date,
+      false                                                                                                                        suppress_from_discovery_srs,
+      COALESCE((instance_record.jsonb ->> 'discoverySuppress')::bool, false)                                                       suppress_from_discovery_inventory,
+      true                                                                                                                         deleted
+      FROM ${myuniversity}_${mymodule}.get_instances_from_inventory_deleted instance_record;


### PR DESCRIPTION
[MODOAIPMH-614](https://folio-org.atlassian.net/browse/MODOAIPMH-614) - Set for deletion FOLIO Instances are harvested with ListRecords, ListIdentifiers requests as not deleted

## Purpose
Deleted in the following ways FOLIO Instances harvested with ListRecords, ListIdentifiers requests as not deleted.

## Approach
Update instances views and add additional UNION ALL to harvest instances with "deleted"=true as well.

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
