### PR TITLE
MODOAIPMH-657 - Include displaySummary in lieu of enumeration and chronology in OAI-PMH withHoldings output

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -430,25 +430,20 @@ public class RecordMetadataManager {
     if (nonNull(itemData)) {
       var isDisplaySummaryPresent = itemData.containsKey(DISPLAY_SUMMARY)
           && isNotEmpty(itemData.getString(DISPLAY_SUMMARY).trim());
+      if (isDisplaySummaryPresent) {
+        effectiveLocationSubFields.put(
+            EffectiveLocationSubFields.ENUMERATION.getSubFieldCode(),
+            itemData.getString(DISPLAY_SUMMARY));
+      }
       subFieldGroupProperties.forEach(pair -> {
         String subFieldCode = pair.getSubFieldCode();
         String subFieldValue = itemData.getString(pair.getJsonPropertyPath());
         if (isNotEmpty(subFieldValue)) {
-          if (isDisplaySummaryPresent && enumerationOrChronologyPredicate.test(subFieldCode)) {
-            addDisplaySummaryToEnumerationAndSkipChronology(effectiveLocationSubFields,
-                subFieldCode, itemData.getString(DISPLAY_SUMMARY));
-          } else {
+          if (!isDisplaySummaryPresent || !enumerationOrChronologyPredicate.test(subFieldCode)) {
             effectiveLocationSubFields.put(subFieldCode, subFieldValue);
           }
         }
       });
-    }
-  }
-
-  private void addDisplaySummaryToEnumerationAndSkipChronology(
-      Map<String, Object> effectiveLocationSubFields, String subFieldCode, String displaySummary) {
-    if (subFieldCode.equals(EffectiveLocationSubFields.ENUMERATION.getSubFieldCode())) {
-      effectiveLocationSubFields.put(subFieldCode, displaySummary);
     }
   }
 

--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -439,7 +439,9 @@ public class RecordMetadataManager {
         String subFieldCode = pair.getSubFieldCode();
         String subFieldValue = itemData.getString(pair.getJsonPropertyPath());
         if (isNotEmpty(subFieldValue)) {
-          if (!isDisplaySummaryPresent || !enumerationOrChronologyPredicate.test(subFieldCode)) {
+          if (isNotEmpty(subFieldValue)
+              && (!isDisplaySummaryPresent
+              || !enumerationOrChronologyPredicate.test(subFieldCode))) {
             effectiveLocationSubFields.put(subFieldCode, subFieldValue);
           }
         }

--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -438,12 +438,10 @@ public class RecordMetadataManager {
       subFieldGroupProperties.forEach(pair -> {
         String subFieldCode = pair.getSubFieldCode();
         String subFieldValue = itemData.getString(pair.getJsonPropertyPath());
-        if (isNotEmpty(subFieldValue)) {
-          if (isNotEmpty(subFieldValue)
-              && (!isDisplaySummaryPresent
-              || !enumerationOrChronologyPredicate.test(subFieldCode))) {
-            effectiveLocationSubFields.put(subFieldCode, subFieldValue);
-          }
+        if (isNotEmpty(subFieldValue)
+            && (!isDisplaySummaryPresent
+            || !enumerationOrChronologyPredicate.test(subFieldCode))) {
+          effectiveLocationSubFields.put(subFieldCode, subFieldValue);
         }
       });
     }

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -618,7 +618,7 @@ class RecordMetadataManagerTest {
   }
 
   @Test
-  void shouldNotAddEnumerationSubfield_whenDisplaySummaryIsPresentButEnumerationIsMissing() {
+  void shouldAddEnumerationSubfield_whenDisplaySummaryIsPresentButEnumerationIsMissing() {
     JsonObject srsInstance = new JsonObject(requireNonNull(getJsonObjectFromFile(
         SRS_INSTANCE_JSON_PATH)));
     JsonObject inventoryInstance = new JsonObject(
@@ -642,8 +642,8 @@ class RecordMetadataManagerTest {
       List<Map<String, Object>> subFieldsList =
           (List<Map<String, Object>>) ((Map<String, Object>) field.getMap()
               .get(EFFECTIVE_LOCATION_FIELD)).get(SUBFIELDS);
-      // enumeration subfield "k" should not exist because original enumeration value was absent
-      assertTrue(subFieldsList.stream().noneMatch(sf -> sf.containsKey("k")));
+      // enumeration subfield "k" should exist even the original enumeration value was absent
+      assertTrue(subFieldsList.stream().anyMatch(sf -> sf.containsKey("k")));
       // chronology subfield "l" should also be skipped since displaySummary is present
       assertTrue(subFieldsList.stream().noneMatch(sf -> sf.containsKey("l")));
     });


### PR DESCRIPTION
[MODOAIPMH-657](https://folio-org.atlassian.net/browse/MODOAIPMH-657) - Include displaySummary in lieu of enumeration and chronology in OAI-PMH withHoldings output

## Purpose
If displaySummary is present, populate k subfield regardless of k or l presence.

## Approach
Change filter for k and l subfields and condition if displaySummary is present.

### TODOS and Open Questions

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
