### PR TITLE
MODOAIPMH-666 - In GetRecord, ListRecords response for MARC Instance 856 field does not include subfield "t" when 1st indicator is blank

### DIFF
--- a/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
+++ b/src/main/java/org/folio/oaipmh/helpers/records/RecordMetadataManager.java
@@ -104,7 +104,7 @@ public class RecordMetadataManager {
         JsonObject dataFieldContent = jsonObject.getJsonObject(ELECTRONIC_ACCESS_FILED_TAG_NUMBER);
         String firstIndicator = dataFieldContent.getString(FIRST_INDICATOR);
         String secondIndicator = dataFieldContent.getString(SECOND_INDICATOR);
-        return StringUtils.isNotBlank(firstIndicator) && StringUtils.isNotEmpty(secondIndicator);
+        return StringUtils.isNotEmpty(firstIndicator) && StringUtils.isNotEmpty(secondIndicator);
       }
       return false;
     };

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -239,11 +239,11 @@ class RecordMetadataManagerTest {
       VertxTestContext testContext) {
     System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, "true");
     vertx.runOnContext(event -> testContext.verify(() -> {
-      JsonObject record = new JsonObject(
+      JsonObject marcRecord = new JsonObject(
           requireNonNull(getJsonObjectFromFile(SRS_INSTANCE_WITH_856_BLANK_FIRST_INDICATOR)));
-      String source = storageHelper.getInstanceRecordSource(record);
+      String source = storageHelper.getInstanceRecordSource(marcRecord);
       String updatedSource = metadataManager
-          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, record);
+          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, marcRecord);
 
       JsonObject jsonFromSource = new JsonObject(updatedSource);
       JsonArray fields = jsonFromSource.getJsonArray(FIELDS);
@@ -270,11 +270,11 @@ class RecordMetadataManagerTest {
       VertxTestContext testContext) {
     System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, "true");
     vertx.runOnContext(event -> testContext.verify(() -> {
-      JsonObject record = new JsonObject(
+      JsonObject marcRecord = new JsonObject(
           requireNonNull(getJsonObjectFromFile(SRS_INSTANCE_WITH_856_EMPTY_FIRST_INDICATOR)));
-      String source = storageHelper.getInstanceRecordSource(record);
+      String source = storageHelper.getInstanceRecordSource(marcRecord);
       String updatedSource = metadataManager
-          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, record);
+          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, marcRecord);
 
       JsonObject jsonFromSource = new JsonObject(updatedSource);
       JsonArray fields = jsonFromSource.getJsonArray(FIELDS);

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -71,6 +71,8 @@ class RecordMetadataManagerTest {
 
   private static final String SRS_INSTANCE_WITH_856_BLANK_FIRST_INDICATOR =
       "/metadata-manager/srs_instance_with_856_blank_first_indicator.json";
+  private static final String SRS_INSTANCE_WITH_856_EMPTY_FIRST_INDICATOR =
+      "/metadata-manager/srs_instance_with_856_empty_first_indicator.json";
 
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_EMPTY =
       "/metadata-manager/electronic_access-empty.json";
@@ -259,6 +261,38 @@ class RecordMetadataManagerTest {
 
       assertTrue(hasSuppressSubfield,
           "856 field with blank first indicator should have 't' subfield added");
+      testContext.completeNow();
+    }));
+  }
+
+  @Test
+  void shouldNotAddSuppressDiscoverySubfieldTo856Field_whenFirstIndicatorIsEmpty(Vertx vertx,
+      VertxTestContext testContext) {
+    System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, "true");
+    vertx.runOnContext(event -> testContext.verify(() -> {
+      JsonObject record = new JsonObject(
+          requireNonNull(getJsonObjectFromFile(SRS_INSTANCE_WITH_856_EMPTY_FIRST_INDICATOR)));
+      String source = storageHelper.getInstanceRecordSource(record);
+      String updatedSource = metadataManager
+          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, record);
+
+      JsonObject jsonFromSource = new JsonObject(updatedSource);
+      JsonArray fields = jsonFromSource.getJsonArray(FIELDS);
+      JsonObject field856 = fields.stream()
+          .map(o -> (JsonObject) o)
+          .filter(o -> o.containsKey(ELECTRONIC_ACCESS_FILED))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("856 field not found"));
+
+      JsonArray subfields = field856.getJsonObject(ELECTRONIC_ACCESS_FILED)
+          .getJsonArray(SUBFIELDS);
+      boolean hasSuppressSubfield = subfields.stream()
+          .map(o -> (JsonObject) o)
+          .anyMatch(o -> o.containsKey("t"));
+
+      assertFalse(hasSuppressSubfield,
+          "856 field with empty first indicator should not have 't' subfield added"
+              + " because electronicAccessPredicate requires isNotEmpty(firstIndicator)");
       testContext.completeNow();
     }));
   }

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -69,6 +69,9 @@ class RecordMetadataManagerTest {
   private static final String INVENTORY_INSTANCE_WITH_ITEM_WITHOUT_CALL_NUMBER =
       "/metadata-manager/inventory_instance_with_item_without_call_number.json";
 
+  private static final String SRS_INSTANCE_WITH_856_BLANK_FIRST_INDICATOR =
+      "/metadata-manager/srs_instance_with_856_blank_first_indicator.json";
+
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_EMPTY =
       "/metadata-manager/electronic_access-empty.json";
   private static final String ITEM_WITH_ELECTRONIC_ACCESS_NO_DISPLAY_CONSTANT_GENERATED =
@@ -225,6 +228,37 @@ class RecordMetadataManagerTest {
       verifySourceWasUpdatedWithNewSubfield(updatedSource,
           metadataManager.getElectronicAccessPredicate(),
           ELECTRONIC_ACCESS_FILED);
+      testContext.completeNow();
+    }));
+  }
+
+  @Test
+  void shouldAddSuppressDiscoverySubfieldTo856Field_whenFirstIndicatorIsBlank(Vertx vertx,
+      VertxTestContext testContext) {
+    System.setProperty(REPOSITORY_SUPPRESSED_RECORDS_PROCESSING, "true");
+    vertx.runOnContext(event -> testContext.verify(() -> {
+      JsonObject record = new JsonObject(
+          requireNonNull(getJsonObjectFromFile(SRS_INSTANCE_WITH_856_BLANK_FIRST_INDICATOR)));
+      String source = storageHelper.getInstanceRecordSource(record);
+      String updatedSource = metadataManager
+          .updateElectronicAccessFieldWithDiscoverySuppressedData(source, record);
+
+      JsonObject jsonFromSource = new JsonObject(updatedSource);
+      JsonArray fields = jsonFromSource.getJsonArray(FIELDS);
+      JsonObject field856 = fields.stream()
+          .map(o -> (JsonObject) o)
+          .filter(o -> o.containsKey(ELECTRONIC_ACCESS_FILED))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("856 field not found"));
+
+      JsonArray subfields = field856.getJsonObject(ELECTRONIC_ACCESS_FILED)
+          .getJsonArray(SUBFIELDS);
+      boolean hasSuppressSubfield = subfields.stream()
+          .map(o -> (JsonObject) o)
+          .anyMatch(o -> o.containsKey("t"));
+
+      assertTrue(hasSuppressSubfield,
+          "856 field with blank first indicator should have 't' subfield added");
       testContext.completeNow();
     }));
   }

--- a/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
+++ b/src/test/java/org/folio/oaipmh/helpers/records/RecordMetadataManagerTest.java
@@ -120,7 +120,7 @@ class RecordMetadataManagerTest {
   }
 
   @Test
-  void shouldUpdateRecordMetadataWithTwoEffectiveLocationFieldsWhenInventoryItemsArrayHasTwoElements() {
+  void shouldUpdateRecordMetadataWithTwoEffLocFieldsWhenInventoryItemsArrayHasTwoElements() {
     JsonObject srsInstance = new JsonObject(requireNonNull(getJsonObjectFromFile(
         SRS_INSTANCE_WITH_ELECTRONIC_ACCESS)));
     JsonObject inventoryInstance = new JsonObject(
@@ -141,7 +141,7 @@ class RecordMetadataManagerTest {
   }
 
   @Test
-  void shouldUpdateRecordMetadataWithTwoElectronicAccessFieldsWhenInventoryItemHasElectronicAccessArrayWithTwoItems() {
+  void shouldUpdateRecordMetadataWithTwoElAccFieldsWhenInventoryItemHasElAccArrayWithTwoItems() {
     JsonObject srsInstance = new JsonObject(requireNonNull(getJsonObjectFromFile(
         SRS_INSTANCE_WITH_ELECTRONIC_ACCESS)));
     JsonObject inventoryInstance = new JsonObject(
@@ -282,7 +282,7 @@ class RecordMetadataManagerTest {
   }
 
   @Test
-  void shouldUpdateFieldsWithEffectiveLocationFieldWithoutLocationsSubfieldGroupWhenInstanceHasItemWithoutLocationData() {
+  void shouldUpdateFieldsWithEffLocFieldWithoutLocSubfieldGroupWhenInstHasItemWithoutLocData() {
     JsonObject srsInstance = new JsonObject(requireNonNull(getJsonObjectFromFile(
         SRS_INSTANCE_WITH_ELECTRONIC_ACCESS)));
     JsonObject inventoryInstance = new JsonObject(
@@ -302,7 +302,7 @@ class RecordMetadataManagerTest {
   }
 
   @Test
-  void shouldUpdateFieldsWithEffectiveLocationFieldWithoutCallNumberSubfieldGroupWhenInstanceHasItemWithoutCallNumber() {
+  void shouldUpdateFieldsWithEffLocFieldWithoutCallNumSubfieldGroupWhenInstHasItmWithoutCallNum() {
     JsonObject srsInstance = new JsonObject(requireNonNull(getJsonObjectFromFile(
         SRS_INSTANCE_WITH_ELECTRONIC_ACCESS)));
     JsonObject inventoryInstance = new JsonObject(

--- a/src/test/resources/metadata-manager/srs_instance_with_856_blank_first_indicator.json
+++ b/src/test/resources/metadata-manager/srs_instance_with_856_blank_first_indicator.json
@@ -1,0 +1,72 @@
+{
+  "recordId": "04489a01-f3cd-4f9e-9be4-d9c198703f45",
+  "snapshotId": "dcca0c83-f338-4434-8770-e33dc31629b8",
+  "recordType": "MARC",
+  "parsedRecord": {
+    "id": "012da750-3792-465f-b02e-8c962130321b",
+    "content": {
+      "leader": "01741nam a2200373 cb4500",
+      "fields": [
+        {
+          "001": "101073931X"
+        },
+        {
+          "003": "DE-601"
+        },
+        {
+          "005": "20180416162657.0"
+        },
+        {
+          "008": "180111s2018    sz            000 0 eng d"
+        },
+        {
+          "856": {
+            "subfields": [
+              {
+                "u": "test.com"
+              },
+              {
+                "y": "GS demo Holding 1_2"
+              },
+              {
+                "z": "URL public note"
+              },
+              {
+                "3": "Materials specified"
+              }
+            ],
+            "ind1": " ",
+            "ind2": "0"
+          }
+        },
+        {
+          "999": {
+            "ind1": "f",
+            "ind2": "f",
+            "subfields": [
+              {
+                "s": "3c4ae3f3-b460-4a89-a2f9-78ce3145e4fc"
+              },
+              {
+                "i": "00000000-0000-4000-a000-000000000000"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "externalIdsHolder": {
+    "instanceId": "2f7f23be-81a6-4227-85ba-7c1c81272ee1"
+  },
+  "additionalInfo": {
+    "suppressDiscovery": true
+  },
+  "metadata": {
+    "createdDate": "2018-11-20T09:14:35.400+0000",
+    "createdByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092",
+    "updatedDate": "2018-11-20T09:14:35.400+0000",
+    "updatedByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092"
+  }
+}
+

--- a/src/test/resources/metadata-manager/srs_instance_with_856_empty_first_indicator.json
+++ b/src/test/resources/metadata-manager/srs_instance_with_856_empty_first_indicator.json
@@ -1,0 +1,72 @@
+{
+  "recordId": "04489a01-f3cd-4f9e-9be4-d9c198703f45",
+  "snapshotId": "dcca0c83-f338-4434-8770-e33dc31629b8",
+  "recordType": "MARC",
+  "parsedRecord": {
+    "id": "012da750-3792-465f-b02e-8c962130321b",
+    "content": {
+      "leader": "01741nam a2200373 cb4500",
+      "fields": [
+        {
+          "001": "101073931X"
+        },
+        {
+          "003": "DE-601"
+        },
+        {
+          "005": "20180416162657.0"
+        },
+        {
+          "008": "180111s2018    sz            000 0 eng d"
+        },
+        {
+          "856": {
+            "subfields": [
+              {
+                "u": "test.com"
+              },
+              {
+                "y": "GS demo Holding 1_2"
+              },
+              {
+                "z": "URL public note"
+              },
+              {
+                "3": "Materials specified"
+              }
+            ],
+            "ind1": "",
+            "ind2": "0"
+          }
+        },
+        {
+          "999": {
+            "ind1": "f",
+            "ind2": "f",
+            "subfields": [
+              {
+                "s": "3c4ae3f3-b460-4a89-a2f9-78ce3145e4fc"
+              },
+              {
+                "i": "00000000-0000-4000-a000-000000000000"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "externalIdsHolder": {
+    "instanceId": "2f7f23be-81a6-4227-85ba-7c1c81272ee1"
+  },
+  "additionalInfo": {
+    "suppressDiscovery": false
+  },
+  "metadata": {
+    "createdDate": "2018-11-20T09:14:35.400+0000",
+    "createdByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092",
+    "updatedDate": "2018-11-20T09:14:35.400+0000",
+    "updatedByUserId": "9df9917d-5c28-5326-82c6-e590e3b56092"
+  }
+}
+


### PR DESCRIPTION
[MODOAIPMH-666](https://folio-org.atlassian.net/browse/MODOAIPMH-666) - In GetRecord, ListRecords response for MARC Instance 856 field does not include subfield "t" when 1st indicator is blank

## Purpose
856 field may include different indicators as described on the [page](https://www.loc.gov/marc/bibliographic/bd856.html). When MARC Instance has 856 field populated with 1st indicator blank, in GetRecord, ListRecords response 856 field does not include subfield "t".

## Approach
Change logic to verify the first indicator in 856 field.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
