### PR TITLE
MOD0AIPMH-669 - Exclude deleted record from full harvests

### DIFF
--- a/src/main/java/org/folio/oaipmh/processors/GetListRecordsRequestHelper.java
+++ b/src/main/java/org/folio/oaipmh/processors/GetListRecordsRequestHelper.java
@@ -250,7 +250,8 @@ public class GetListRecordsRequestHelper extends AbstractGetRecordsHelper {
     logger.info("Before doRequest, limit: {}", limit);
     long t = System.nanoTime();
     boolean deletedRecordsSupport =
-        RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId());
+        (nonNull(dateFrom) || nonNull(dateUntil))
+            && RepositoryConfigurationUtil.isDeletedRecordsEnabled(request.getRequestId());
     boolean skipSuppressedFromDiscovery = isSkipSuppressed(request);
     var recordsSource = getProperty(request.getRequestId(), REPOSITORY_RECORDS_SOURCE);
     doRequest(request, finalRecords, skipSuppressedFromDiscovery, deletedRecordsSupport, from,

--- a/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
+++ b/src/test/java/org/folio/rest/impl/OaiPmhImplTest.java
@@ -1959,7 +1959,7 @@ class OaiPmhImplTest {
       totalRecords += oaipmh.getListRecords().getRecords().size();
       resumptionToken = getResumptionToken(oaipmh, LIST_RECORDS).getValue();
     }
-    assertThat(totalRecords, is(67));
+    assertThat(totalRecords, is(66));
     System.setProperty(REPOSITORY_MAX_RECORDS_PER_RESPONSE, currentValue);
     String repositoryDeletedRecords = System.getProperty(REPOSITORY_DELETED_RECORDS);
     System.setProperty(REPOSITORY_DELETED_RECORDS, repositoryDeletedRecords);


### PR DESCRIPTION
[MOD0AIPMH-669](https://folio-org.atlassian.net/browse/MODOAIPMH-669) - Exclude deleted record from full harvests

## Purpose
The purpose of the full harvest is to recreate the entire library catalog. It has been proposed to exclude records that are set for deletion from full harvests. This is intended to help performance because there is a significantly increased large number of instances set for deletion.

## Approach
Change deletedRecordsSupport to false if no parameters from/until.

### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
