### PR TITLE
MODOAIPMH-672 Invalid special characters encoding

### DIFF
--- a/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
+++ b/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
@@ -36,7 +36,8 @@ public class OaiPmhJsonParser extends JsonParserImpl {
     } catch (DecodeException e) {
       var errorResolver = new JsonParserErrorResolver(data.toString(), e.getLocalizedMessage());
       logger.error(e.getLocalizedMessage());
-      logger.error("Decode parser exception: Error position at error part of json is {}", errorResolver.getErrorPosition());
+      logger.error("Decode parser exception: Error position at error part of json is {}",
+          errorResolver.getErrorPosition());
       logger.error(errorResolver.getErrorPart());
       errors.add(errorResolver.getErrorPart());
       if (handle(e)) {

--- a/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
+++ b/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
@@ -31,14 +31,13 @@ public class OaiPmhJsonParser extends JsonParserImpl {
 
   @Override
   public void handle(Buffer data) {
-    var normalized =  data.toString().replaceAll("([\\r\\n])", "");
     try {
-      super.handle(Buffer.buffer(normalized));
+      super.handle(data);
     } catch (DecodeException e) {
-      var errorResolver = new JsonParserErrorResolver(normalized, e.getLocalizedMessage());
+      var errorResolver = new JsonParserErrorResolver(data.toString(), e.getLocalizedMessage());
       logger.error(e.getLocalizedMessage());
       logger.error("Decode parser exception: Error position at error part of json is {}",
-          errorResolver.getErrorPosition());
+        errorResolver.getErrorPosition());
       logger.error(errorResolver.getErrorPart());
       errors.add(errorResolver.getErrorPart());
       if (handle(e)) {

--- a/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
+++ b/src/main/java/org/folio/oaipmh/processors/OaiPmhJsonParser.java
@@ -36,8 +36,7 @@ public class OaiPmhJsonParser extends JsonParserImpl {
     } catch (DecodeException e) {
       var errorResolver = new JsonParserErrorResolver(data.toString(), e.getLocalizedMessage());
       logger.error(e.getLocalizedMessage());
-      logger.error("Decode parser exception: Error position at error part of json is {}",
-        errorResolver.getErrorPosition());
+      logger.error("Decode parser exception: Error position at error part of json is {}", errorResolver.getErrorPosition());
       logger.error(errorResolver.getErrorPart());
       errors.add(errorResolver.getErrorPart());
       if (handle(e)) {


### PR DESCRIPTION
## Purpose

Wrong encoding of polish special characters (e.g. ń). There is "Gda  sk" in 952b and should be "Gdańsk":

<marc:datafield tag="952" ind1="f" ind2="f">
            <marc:subfield code="p">do wypożyczenia</marc:subfield>
            <marc:subfield code="a">Biblioteka Gdańska PAN</marc:subfield>
            <marc:subfield code="b">Gda  sk</marc:subfield>
            <marc:subfield code="c">Nowy Gmach</marc:subfield>
            <marc:subfield code="d">Magazyn w nowym gmachu</marc:subfield>
            <marc:subfield code="t">0</marc:subfield>
            <marc:subfield code="e">I 296589</marc:subfield>
            <marc:subfield code="h">Według sygnatur</marc:subfield>
            <marc:subfield code="i">książka</marc:subfield>
            <marc:subfield code="m">1000066703</marc:subfield>
</marc:datafield>

https://folio-org.atlassian.net/browse/MODOAIPMH-672

## Approach
OaiPmhJsonParser.handle(Buffer) calls Buffer.toString() per chunk before feeding Jackson; multi-byte UTF-8 characters split across HTTP response chunks from inventory-hierarchy are decoded to U+FFFD, corrupting 952b (should be Gdańsk) location data non-deterministically.

Removing replaceAll("[\\r\\n]","") is safe: in JSON, CR/LF between tokens is insignificant whitespace (Jackson ignores it), while raw CR/LF inside strings is illegal, so it will not occur. However, if removing CR/LF is actually necessary for some reason, the only correct approach is filtering 0x0D/0x0A bytes on the Buffer (since they are single-byte ASCII and never part of a multibyte sequence).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
